### PR TITLE
feat: surface update availability notice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
             curl \
             wget \
             file \
+            xdg-utils \
             pkg-config \
             libssl-dev \
             libgtk-3-dev \
@@ -212,6 +213,36 @@ jobs:
           shared-key: ${{ matrix.target }}
           cache-all-crates: true
           cache-on-failure: true
+
+      - name: Cache Tauri downloads (Linux)
+        if: runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/tauri
+          key: tauri-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('src-tauri/tauri.conf.json') }}
+          restore-keys: |
+            tauri-${{ runner.os }}-${{ matrix.target }}-
+            tauri-${{ runner.os }}-
+
+      - name: Cache Tauri downloads (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/tauri
+          key: tauri-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('src-tauri/tauri.conf.json') }}
+          restore-keys: |
+            tauri-${{ runner.os }}-${{ matrix.target }}-
+            tauri-${{ runner.os }}-
+
+      - name: Cache Tauri downloads (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: '${{ env.LOCALAPPDATA }}\\tauri'
+          key: tauri-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('src-tauri/tauri.conf.json') }}
+          restore-keys: |
+            tauri-${{ runner.os }}-${{ matrix.target }}-
+            tauri-${{ runner.os }}-
 
       - name: Install frontend dependencies
         run: npm ci
@@ -272,6 +303,7 @@ jobs:
             curl \
             wget \
             file \
+            xdg-utils \
             libssl-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
@@ -301,6 +333,36 @@ jobs:
           shared-key: pr-${{ matrix.target }}
           cache-all-crates: true
           cache-on-failure: true
+
+      - name: Cache Tauri downloads (Linux)
+        if: runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/tauri
+          key: tauri-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('src-tauri/tauri.conf.json') }}
+          restore-keys: |
+            tauri-${{ runner.os }}-${{ matrix.target }}-
+            tauri-${{ runner.os }}-
+
+      - name: Cache Tauri downloads (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/tauri
+          key: tauri-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('src-tauri/tauri.conf.json') }}
+          restore-keys: |
+            tauri-${{ runner.os }}-${{ matrix.target }}-
+            tauri-${{ runner.os }}-
+
+      - name: Cache Tauri downloads (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: '${{ env.LOCALAPPDATA }}\\tauri'
+          key: tauri-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('src-tauri/tauri.conf.json') }}
+          restore-keys: |
+            tauri-${{ runner.os }}-${{ matrix.target }}-
+            tauri-${{ runner.os }}-
 
       - name: Install frontend dependencies
         run: npm ci

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tauri-plugin-shell = "2.3.1"
 tauri-plugin-decorum = "1.1.1"
 tauri-plugin-dialog = "2.4.0"
 tauri-plugin-drag = "2.1.0"
+tauri-plugin-opener = "2.5.0"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,7 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_decorum::init())
         .plugin(tauri_plugin_drag::init())

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -2,6 +2,9 @@ use tauri::{
     menu::{AboutMetadata, CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder, SubmenuBuilder},
     AppHandle, Emitter, Manager, Runtime,
 };
+use tauri_plugin_opener::OpenerExt;
+
+const GITHUB_REPO_URL: &str = "https://github.com/StirlingMarketingGroup/marlin";
 
 pub fn create_menu<R: Runtime>(
     app: &AppHandle<R>,
@@ -127,6 +130,10 @@ pub fn create_menu<R: Runtime>(
         .fullscreen()
         .build()?;
 
+    let help_submenu = SubmenuBuilder::new(app, "Help")
+        .text("menu:view_github", "View on GitHub")
+        .build()?;
+
     // Build the complete menu with all submenus
     let menu = MenuBuilder::new(app)
         .items(&[
@@ -135,6 +142,7 @@ pub fn create_menu<R: Runtime>(
             &edit_submenu,
             &view_submenu,
             &window_submenu,
+            &help_submenu,
         ])
         .build()?;
 
@@ -329,6 +337,11 @@ pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: &tauri::menu::Me
         }
         "menu:new_window" => {
             let _ = app.emit("menu:new_window", ());
+        }
+        "menu:view_github" => {
+            if let Err(error) = app.opener().open_url(GITHUB_REPO_URL, None::<&str>) {
+                log::warn!("Failed to open GitHub repo page: {error}");
+            }
         }
         "ctx:toggle_hidden" => {
             let state: tauri::State<crate::state::MenuState<R>> = app.state();

--- a/src/components/PathBar.tsx
+++ b/src/components/PathBar.tsx
@@ -14,6 +14,7 @@ import {
 import { useAppStore } from '../store/useAppStore';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import ZoomSlider from './ZoomSlider';
+import UpdateNotice from '@/components/UpdateNotice';
 
 export default function PathBar() {
   const { currentPath, navigateTo, showZoomSliderNow, scheduleHideZoomSlider, showZoomSlider } =
@@ -163,42 +164,46 @@ export default function PathBar() {
         />
       </div>
 
-      {/* View toggles */}
-      <div className="flex items-center gap-1">
-        <button
-          className={`btn-icon ${
-            (useAppStore.getState().directoryPreferences[currentPath]?.viewMode ||
-              useAppStore.getState().globalPreferences.viewMode) === 'grid'
-              ? 'bg-accent-soft text-accent'
-              : ''
-          }`}
-          onClick={() =>
-            useAppStore.getState().updateDirectoryPreferences(currentPath, { viewMode: 'grid' })
-          }
-          title="Icons"
-          data-tauri-drag-region={false}
-          onMouseEnter={() => showZoomSliderNow()}
-          onMouseLeave={() => scheduleHideZoomSlider(400)}
-          onFocus={() => showZoomSliderNow()}
-          onBlur={() => scheduleHideZoomSlider(400)}
-        >
-          <SquaresFour className="w-4 h-4 text-accent" />
-        </button>
-        <button
-          className={`btn-icon ${
-            (useAppStore.getState().directoryPreferences[currentPath]?.viewMode ||
-              useAppStore.getState().globalPreferences.viewMode) === 'list'
-              ? 'bg-accent-soft text-accent'
-              : ''
-          }`}
-          onClick={() =>
-            useAppStore.getState().updateDirectoryPreferences(currentPath, { viewMode: 'list' })
-          }
-          title="List"
-          data-tauri-drag-region={false}
-        >
-          <List className="w-4 h-4 text-accent" />
-        </button>
+      {/* View toggles + update notice */}
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          <button
+            className={`btn-icon ${
+              (useAppStore.getState().directoryPreferences[currentPath]?.viewMode ||
+                useAppStore.getState().globalPreferences.viewMode) === 'grid'
+                ? 'bg-accent-soft text-accent'
+                : ''
+            }`}
+            onClick={() =>
+              useAppStore.getState().updateDirectoryPreferences(currentPath, { viewMode: 'grid' })
+            }
+            title="Icons"
+            data-tauri-drag-region={false}
+            onMouseEnter={() => showZoomSliderNow()}
+            onMouseLeave={() => scheduleHideZoomSlider(400)}
+            onFocus={() => showZoomSliderNow()}
+            onBlur={() => scheduleHideZoomSlider(400)}
+          >
+            <SquaresFour className="w-4 h-4 text-accent" />
+          </button>
+          <button
+            className={`btn-icon ${
+              (useAppStore.getState().directoryPreferences[currentPath]?.viewMode ||
+                useAppStore.getState().globalPreferences.viewMode) === 'list'
+                ? 'bg-accent-soft text-accent'
+                : ''
+            }`}
+            onClick={() =>
+              useAppStore.getState().updateDirectoryPreferences(currentPath, { viewMode: 'list' })
+            }
+            title="List"
+            data-tauri-drag-region={false}
+          >
+            <List className="w-4 h-4 text-accent" />
+          </button>
+        </div>
+
+        <UpdateNotice />
       </div>
 
       {isLinux && (

--- a/src/components/UpdateNotice.tsx
+++ b/src/components/UpdateNotice.tsx
@@ -1,0 +1,40 @@
+import { ArrowSquareOut } from 'phosphor-react';
+import { open } from '@tauri-apps/plugin-shell';
+import { useUpdateCheck } from '@/hooks/useUpdateCheck';
+
+async function openReleasePage(url: string) {
+  try {
+    await open(url);
+  } catch (error) {
+    try {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    } catch (fallbackError) {
+      console.warn('Unable to open release page:', fallbackError || error);
+    }
+  }
+}
+
+export default function UpdateNotice() {
+  const { updateAvailable, latestVersion, releaseUrl, checking, error } = useUpdateCheck();
+
+  if (checking || error || !updateAvailable || !latestVersion) {
+    return null;
+  }
+
+  const label = `Marlin ${latestVersion} is available`;
+
+  return (
+    <button
+      type="button"
+      className="flex items-center gap-2 text-sm px-3 py-1 rounded-md bg-accent-soft text-accent border border-accent/40 hover:border-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+      data-tauri-drag-region={false}
+      onClick={() => void openReleasePage(releaseUrl)}
+      title={label}
+      aria-label={label}
+    >
+      <span className="font-medium">Update available</span>
+      <span className="text-xs text-app-muted">{latestVersion}</span>
+      <ArrowSquareOut className="w-4 h-4" />
+    </button>
+  );
+}

--- a/src/components/UpdateNotice.tsx
+++ b/src/components/UpdateNotice.tsx
@@ -1,6 +1,9 @@
-import { ArrowSquareOut } from 'phosphor-react';
+import { ArrowSquareOut, X } from 'phosphor-react';
+import { useState } from 'react';
 import { open } from '@tauri-apps/plugin-shell';
 import { useUpdateCheck } from '@/hooks/useUpdateCheck';
+
+const DISMISS_KEY = 'marlin:update-dismissed-version';
 
 async function openReleasePage(url: string) {
   try {
@@ -14,27 +17,71 @@ async function openReleasePage(url: string) {
   }
 }
 
+const readDismissedVersion = () => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(DISMISS_KEY);
+  } catch (error) {
+    console.warn('Failed to read dismissed update version:', error);
+    return null;
+  }
+};
+
+const persistDismissedVersion = (version: string) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(DISMISS_KEY, version);
+  } catch (error) {
+    console.warn('Failed to persist dismissed update version:', error);
+  }
+};
+
 export default function UpdateNotice() {
   const { updateAvailable, latestVersion, releaseUrl, checking, error } = useUpdateCheck();
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(() =>
+    readDismissedVersion()
+  );
 
-  if (checking || error || !updateAvailable || !latestVersion) {
+  const versionLabel = latestVersion?.trim() ?? '';
+  const dismissed = Boolean(versionLabel) && dismissedVersion === versionLabel;
+
+  if (checking || error || !updateAvailable || !versionLabel || dismissed) {
     return null;
   }
 
-  const label = `Marlin ${latestVersion} is available`;
+  const label = `Marlin ${versionLabel} is available`;
+
+  const handleDismiss = () => {
+    setDismissedVersion(versionLabel);
+    persistDismissedVersion(versionLabel);
+  };
 
   return (
-    <button
-      type="button"
-      className="flex items-center gap-2 text-sm px-3 py-1 rounded-md bg-accent-soft text-accent border border-accent/40 hover:border-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+    <div
+      className="flex items-center gap-2 text-sm px-3 py-1 rounded-md bg-accent-soft text-accent border border-accent/40 hover:border-accent transition-colors"
       data-tauri-drag-region={false}
-      onClick={() => void openReleasePage(releaseUrl)}
-      title={label}
-      aria-label={label}
+      role="alert"
+      aria-live="polite"
     >
-      <span className="font-medium">Update available</span>
-      <span className="text-xs text-app-muted">{latestVersion}</span>
-      <ArrowSquareOut className="w-4 h-4" />
-    </button>
+      <button
+        type="button"
+        className="flex items-center gap-2 px-2 py-0.5 rounded-md border border-transparent hover:border-accent/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+        onClick={() => void openReleasePage(releaseUrl)}
+        title={label}
+        aria-label={label}
+      >
+        <span className="font-medium">Update available</span>
+        <span className="text-xs text-app-muted">{versionLabel}</span>
+        <ArrowSquareOut className="w-4 h-4" />
+      </button>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        className="flex shrink-0 items-center justify-center rounded-md p-1 text-app-muted hover:text-app-foreground hover:bg-accent/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+        aria-label="Dismiss update notification"
+      >
+        <X className="w-4 h-4" weight="bold" />
+      </button>
+    </div>
   );
 }

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react';
+import { getVersion } from '@tauri-apps/api/app';
+
+const GITHUB_RELEASES_API =
+  'https://api.github.com/repos/StirlingMarketingGroup/marlin/releases/latest';
+const RELEASES_PAGE = 'https://github.com/StirlingMarketingGroup/marlin/releases';
+const CACHE_KEY = 'marlin:update-info';
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+type GithubRelease = {
+  tag_name: string;
+  html_url: string;
+  draft?: boolean;
+  prerelease?: boolean;
+};
+
+type UpdateCache = {
+  latestVersion: string;
+  releaseUrl: string;
+  checkedAt: number;
+};
+
+type UpdateState = {
+  checking: boolean;
+  updateAvailable: boolean;
+  currentVersion: string | null;
+  latestVersion: string | null;
+  releaseUrl: string;
+  error: string | null;
+};
+
+const initialState: UpdateState = {
+  checking: true,
+  updateAvailable: false,
+  currentVersion: null,
+  latestVersion: null,
+  releaseUrl: RELEASES_PAGE,
+  error: null,
+};
+
+const safeParse = (version: string | null | undefined) => (version || '').trim().replace(/^v/i, '');
+
+const extractNumericSegments = (version: string) => {
+  const core = version.split('-')[0];
+  return core
+    .split('.')
+    .map((segment) => Number.parseInt(segment, 10))
+    .filter((segment) => Number.isFinite(segment));
+};
+
+const isVersionNewer = (current: string, latest: string) => {
+  const currentSegments = extractNumericSegments(safeParse(current));
+  const latestSegments = extractNumericSegments(safeParse(latest));
+  const length = Math.max(currentSegments.length, latestSegments.length);
+
+  for (let i = 0; i < length; i += 1) {
+    const currentValue = currentSegments[i] ?? 0;
+    const latestValue = latestSegments[i] ?? 0;
+    if (latestValue > currentValue) return true;
+    if (latestValue < currentValue) return false;
+  }
+
+  return false;
+};
+
+const loadCache = (): UpdateCache | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as UpdateCache;
+    if (!parsed.latestVersion || !parsed.releaseUrl || !parsed.checkedAt) {
+      return null;
+    }
+    if (Date.now() - parsed.checkedAt > CACHE_TTL_MS) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to read cached update info:', error);
+    return null;
+  }
+};
+
+const saveCache = (payload: UpdateCache) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Failed to cache update info:', error);
+  }
+};
+
+const resolveCurrentVersion = async (): Promise<string> => {
+  try {
+    return await getVersion();
+  } catch (error) {
+    console.warn('Failed to retrieve app version from Tauri runtime:', error);
+  }
+
+  if (typeof import.meta !== 'undefined') {
+    const env = import.meta.env as Record<string, string | undefined>;
+    if (env?.VITE_APP_VERSION) return env.VITE_APP_VERSION;
+    if (env?.TAURI_APP_VERSION) return env.TAURI_APP_VERSION;
+    if (env?.npm_package_version) return env.npm_package_version;
+  }
+
+  return '0.0.0';
+};
+
+const fetchLatestRelease = async (): Promise<UpdateCache> => {
+  const response = await fetch(GITHUB_RELEASES_API, {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub responded with ${response.status}`);
+  }
+
+  const data = (await response.json()) as GithubRelease;
+  const latestVersion = safeParse(data.tag_name);
+  const releaseUrl = data.html_url || RELEASES_PAGE;
+
+  if (!latestVersion) {
+    throw new Error('Latest release is missing a tag name');
+  }
+
+  const payload: UpdateCache = {
+    latestVersion,
+    releaseUrl,
+    checkedAt: Date.now(),
+  };
+
+  saveCache(payload);
+  return payload;
+};
+
+export function useUpdateCheck() {
+  const [state, setState] = useState<UpdateState>(initialState);
+
+  useEffect(() => {
+    let disposed = false;
+
+    const checkUpdates = async () => {
+      setState((prev) => ({ ...prev, checking: true, error: null }));
+
+      try {
+        const currentVersion = await resolveCurrentVersion();
+        if (disposed) return;
+
+        const cached = loadCache();
+        const base = cached ?? (await fetchLatestRelease());
+        if (disposed) return;
+
+        // If cache was used but stale, refresh in background once
+        if (cached) {
+          fetchLatestRelease()
+            .then((fresh) => {
+              if (disposed) return;
+              setState((prev) => ({
+                ...prev,
+                latestVersion: fresh.latestVersion,
+                releaseUrl: fresh.releaseUrl,
+                updateAvailable: isVersionNewer(currentVersion, fresh.latestVersion),
+              }));
+            })
+            .catch((error) => {
+              console.warn('Background update check failed:', error);
+            });
+        }
+
+        setState({
+          checking: false,
+          currentVersion,
+          latestVersion: base.latestVersion,
+          releaseUrl: base.releaseUrl,
+          updateAvailable: isVersionNewer(currentVersion, base.latestVersion),
+          error: null,
+        });
+      } catch (error) {
+        if (disposed) return;
+        console.warn('Failed to check for updates:', error);
+        setState((prev) => ({
+          ...prev,
+          checking: false,
+          updateAvailable: false,
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      }
+    };
+
+    checkUpdates();
+
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- add useUpdateCheck hook to compare current build with latest GitHub release and cache results
- surface an UpdateNotice pill in the toolbar to open the releases page via the shell plugin (with browser fallback)
- integrate the notice alongside existing view controls without disturbing layout

## Testing
- npm run typecheck