### PR TITLE
chore: fix release workflow linux deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,13 +188,6 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev
 
-      - name: Install cross toolchain (Ubuntu x64)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get install -y \
-            g++-aarch64-linux-gnu \
-            pkg-config-aarch64-linux-gnu
-
       - uses: actions/setup-node@v5
         with:
           node-version: 20

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ Prefer to build locally or script your own pipeline? See the
 - [Node.js](https://nodejs.org/) 18+
 - [Rust](https://rustup.rs/) 1.77+
 - [Tauri CLI](https://tauri.app/v1/guides/getting-started/prerequisites)
+- Linux (Debian/Ubuntu) builds also need the GTK/WebKit toolchain:
+
+  ```bash
+  sudo apt update
+  sudo apt install build-essential pkg-config libwebkit2gtk-4.1-dev \
+    libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+  ```
 
 ### Setup
 
@@ -184,6 +191,10 @@ npm install
 # Start development server
 npm run tauri dev
 ```
+
+> Tip: running inside a Snap-distributed terminal/editor can inject an old
+> `LD_LIBRARY_PATH`. Launch the dev server with `env -u LD_LIBRARY_PATH npm run tauri dev`
+> if you hit glibc-related symbol errors.
 
 ### Build
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,9 +27,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": [
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ]
+    "icon": ["icons/icon.icns", "icons/icon.ico"]
   }
 }


### PR DESCRIPTION
## Summary
- drop the unused cross-compilation toolchain install that referenced a non-existent pkg-config package
- spell out the GTK/WebKit dependencies Linux devs need to install locally
- add guidance for clearing Snap-provided LD_LIBRARY_PATH when running the dev server

## Testing
- npm run check
- cargo check