### PR TITLE
feat: polish linux chrome and menu handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "tauri": "tauri",
+    "tauri": "node ./scripts/run-tauri.mjs",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,3 +64,6 @@ block = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = ["Win32_Storage_FileSystem"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk = { version = "0.18", package = "gtk" }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,10 @@
     "core:default",
     "core:window:allow-start-dragging",
     "dialog:default",
-    "shell:allow-open"
+    "shell:allow-open",
+    "core:window:allow-minimize",
+    "core:window:allow-maximize",
+    "core:window:allow-unmaximize",
+    "core:window:allow-close"
   ]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1066,6 +1066,28 @@ pub fn set_last_dir(path: String) -> Result<(), String> {
     write_prefs_value(&v)
 }
 
+#[tauri::command]
+pub fn toggle_menu_visibility(app: AppHandle) -> Result<bool, String> {
+    #[cfg(target_os = "linux")]
+    {
+        let window = app
+            .get_webview_window("main")
+            .ok_or_else(|| "Main window not found".to_string())?;
+        let is_visible = window.is_menu_visible().map_err(|e| e.to_string())?;
+        if is_visible {
+            window.hide_menu().map_err(|e| e.to_string())?;
+        } else {
+            window.show_menu().map_err(|e| e.to_string())?;
+        }
+        Ok(!is_visible)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = app;
+        Ok(true)
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[tauri::command]
 pub fn start_native_drag(

--- a/src/components/FileGrid.tsx
+++ b/src/components/FileGrid.tsx
@@ -239,7 +239,6 @@ export default function FileGrid({ files, preferences }: FileGridProps) {
   const { startNativeDrag, endNativeDrag, isDraggedDirectory } = useDragStore();
   const [renameText, setRenameText] = useState<string>('');
   const [draggedFile, setDraggedFile] = useState<string | null>(null);
-  const [hoveredFile, setHoveredFile] = useState<string | null>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
   const [flashPath, setFlashPath] = useState<string | null>(null);
@@ -492,9 +491,8 @@ export default function FileGrid({ files, preferences }: FileGridProps) {
           } catch (error) {
             console.warn('Native drag failed:', error);
           } finally {
-            // Clear dragging state and hover state
+            // Clear dragging state
             setDraggedFile(null);
-            setHoveredFile(null);
             // If we were tracking a directory drag, end it
             if (file.is_directory) {
               endNativeDrag();
@@ -842,9 +840,7 @@ export default function FileGrid({ files, preferences }: FileGridProps) {
               className={`relative flex flex-col items-center px-3 py-2 rounded-md cursor-pointer transition-all duration-75 ${
                 isSelected || isRenaming
                   ? 'bg-accent-selected z-20 overflow-visible'
-                  : hoveredFile === file.path
-                    ? 'bg-app-light/70'
-                    : ''
+                  : 'hover:bg-app-light/70'
               } ${isDragged ? 'opacity-50' : ''} ${file.is_hidden ? 'opacity-60' : ''}`}
               data-file-item="true"
               data-file-path={file.path}
@@ -863,8 +859,6 @@ export default function FileGrid({ files, preferences }: FileGridProps) {
                 handleDoubleClick(file);
               }}
               onMouseDown={(e) => handleMouseDownForFile(e, file)}
-              onMouseEnter={() => setHoveredFile(file.path)}
-              onMouseLeave={() => setHoveredFile(null)}
               draggable={false}
             >
               <div

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -158,7 +158,6 @@ export default function FileList({ files, preferences }: FileListProps) {
   const renameInputRef = useRef<HTMLInputElement>(null);
   const { fetchAppIcon } = useAppStore();
   const [draggedFile, setDraggedFile] = useState<string | null>(null);
-  const [hoveredFile, setHoveredFile] = useState<string | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const [flashPath, setFlashPath] = useState<string | null>(null);
   const flashTimeoutRef = useRef<number | undefined>(undefined);
@@ -488,9 +487,8 @@ export default function FileList({ files, preferences }: FileListProps) {
           } catch (error) {
             console.warn('Native drag failed:', error);
           } finally {
-            // Clear dragging state and hover state
+            // Clear dragging state
             setDraggedFile(null);
-            setHoveredFile(null);
             // If we were tracking a directory drag, end it
             if (file.is_directory) {
               endNativeDrag();
@@ -768,12 +766,8 @@ export default function FileList({ files, preferences }: FileListProps) {
             return (
               <div
                 key={file.path}
-                className={`relative grid grid-cols-12 gap-3 py-[2px] leading-5 text-[13px] cursor-pointer transition-colors duration-75 rounded-full ${
-                  isSelected
-                    ? 'bg-accent-selected text-white'
-                    : hoveredFile === file.path
-                      ? 'bg-app-light'
-                      : 'odd:bg-app-gray'
+                className={`relative grid grid-cols-12 gap-3 py-[2px] leading-5 text-[13px] cursor-pointer transition-colors duration-75 rounded-full odd:bg-app-gray ${
+                  isSelected ? 'bg-accent-selected text-white' : 'hover:bg-app-light'
                 } ${isDragged ? 'opacity-50' : ''} ${file.is_hidden ? 'opacity-60' : ''}`}
                 data-file-item="true"
                 data-file-path={file.path}
@@ -792,8 +786,6 @@ export default function FileList({ files, preferences }: FileListProps) {
                   handleDoubleClick(file);
                 }}
                 onMouseDown={(e) => handleMouseDownForFile(e, file)}
-                onMouseEnter={() => setHoveredFile(file.path)}
-                onMouseLeave={() => setHoveredFile(null)}
                 draggable={false}
               >
                 {/* Name column */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -286,6 +286,10 @@ export default function Sidebar() {
     weight: 'fill' | 'regular';
   }[];
 
+  const dragRegionHeightClass = isMac ? 'h-16' : 'h-0';
+  const listTopOffsetClass = isMac ? '-mt-8' : '';
+  const listPaddingTopClass = 'pt-2';
+
   return (
     <div
       ref={sidebarRef}
@@ -299,7 +303,7 @@ export default function Sidebar() {
     >
       {/* Expanded draggable area around traffic lights - covers entire top area */}
       <div
-        className="h-16 w-full select-none"
+        className={`${dragRegionHeightClass} w-full select-none`}
         data-tauri-drag-region
         onMouseDown={async (e: MouseEvent<HTMLDivElement>) => {
           if (e.button !== 0) return;
@@ -320,7 +324,9 @@ export default function Sidebar() {
       />
 
       {/* Flat list */}
-      <div className="flex-1 overflow-y-auto px-2 py-2 pb-2 space-y-[2px] -mt-8">
+      <div
+        className={`flex-1 overflow-y-auto px-2 ${listPaddingTopClass} pb-2 space-y-[2px] ${listTopOffsetClass}`}
+      >
         {/* Favorites section */}
         <div className="px-1 py-1 text-xs text-app-muted select-none">Favorites</div>
         {/* User directories */}

--- a/src/index.css
+++ b/src/index.css
@@ -16,8 +16,9 @@
   --color-accent-soft: var(--accent-soft);
   --color-accent-selected: var(--accent-selected);
   --font-sans:
-    'ui-sans-serif', '-apple-system', 'BlinkMacSystemFont', 'SF Pro Text', 'SF Pro Display',
-    'Segoe UI', 'Helvetica Neue', 'Helvetica', 'Arial', 'Noto Sans', 'Liberation Sans', 'sans-serif';
+    system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', 'Segoe UI',
+    'Ubuntu', 'Cantarell', 'Noto Sans', 'Liberation Sans', 'Helvetica Neue', 'Helvetica', 'Arial',
+    sans-serif;
   --font-mono: 'JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace';
 }
 
@@ -101,7 +102,7 @@
   }
 
   .input-field {
-    @apply bg-app-gray border border-app-border rounded-md px-3 py-2 text-app-text placeholder-app-muted focus:outline-none focus:border-app-accent;
+    @apply bg-app-gray border border-app-border rounded-md px-3 py-1.5 text-app-text placeholder-app-muted focus:outline-none focus:border-app-accent;
     -webkit-app-region: no-drag;
   }
 
@@ -113,7 +114,7 @@
 
   /* Header/toolbar surface: flat, subtle divider */
   .toolbar {
-    @apply flex items-center gap-2 px-3 py-3 bg-transparent;
+    @apply flex items-center gap-2 px-3 py-2 bg-transparent;
   }
 
   /* Breadcrumb chip */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
   },
   server: {
     port: 1420,
-    strictPort: true,
+    strictPort: false,
+    watch: {
+      ignored: ['**/src-tauri/target/**'],
+    },
   },
   envPrefix: ['VITE_', 'TAURI_'],
   build: {


### PR DESCRIPTION
## Summary
- hide the native menu on Linux, apply GTK styling, and add a toggle command invoked when Alt is released
- expose Linux window controls in the path bar, keep drag regions working, and clean up hover styling in both views
- wrap tauri launches in a Snap-aware script, relax the dev server port, and tweak fonts/inputs for better Linux defaults

## Testing
- `npm run build`
- `npm run lint`
- `npm run format`
- `npm run typecheck`
- `cargo check`
