### PR TITLE
chore: auto-sync version metadata on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,14 +103,8 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Abort on mismatched tag contents
-        if: github.event_name != 'workflow_dispatch' && steps.diff.outputs.changed == 'true'
-        run: |
-          echo "Version files differ from release tag $RELEASE_TAG. Please update the code and recreate the tag before releasing." >&2
-          exit 1
-
       - name: Commit version bump
-        if: github.event_name == 'workflow_dispatch' && steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'chore: sync version to ${{ env.RELEASE_TAG }}'
@@ -119,11 +113,19 @@ jobs:
           commit_user_email: releases@marlin.app
 
       - name: Ensure release tag exists
-        if: github.event_name == 'workflow_dispatch'
+        if: steps.diff.outputs.changed == 'true'
         run: |
           git fetch --tags --force
           git tag -f "$RELEASE_TAG"
           git push origin "refs/tags/$RELEASE_TAG" --force
+
+      - name: Verify tag matches synced version
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          if ! git diff --quiet; then
+            echo "Version sync failed; release tag $RELEASE_TAG still differs." >&2
+            exit 1
+          fi
 
   release:
     name: Release (${{ matrix.os }} • ${{ matrix.arch }})


### PR DESCRIPTION
## Summary
- allow the sync job to commit version bumps even when triggered by tag pushes
- retag the release once the version files are updated
- add a guard that ensures the repo is clean before building installers

## Testing
- npm run lint:changed
- npm run format
- npm run typecheck
- cargo check