### PR TITLE
feat: add folder size modal

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,6 +63,14 @@ jobs:
           profile: minimal
           override: true
 
+      - name: Cache cargo build artifacts
+        if: steps.changes.outputs.check == 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri -> target
+          cache-on-failure: true
+
       - name: Install dependencies
         if: steps.changes.outputs.check == 'true'
         run: npm ci

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,7 @@ resvg = { version = "0.45", default-features = true }
 usvg = { version = "0.45", default-features = true, features = ["text"] }
 # File system watching
 notify = { version = "8.2", default-features = false, features = ["macos_fsevent"] }
+walkdir = "2.5"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,17 +1,27 @@
 use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use dirs;
+use log::{info, warn};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as OsCommand;
-use std::sync::Arc;
-use tauri::{command, AppHandle, Manager};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tauri::{command, AppHandle, Emitter, Manager};
 use tokio::process::Command as TokioCommand;
 use tokio::sync::OnceCell;
+use uuid::Uuid;
+use walkdir::WalkDir;
+
+#[cfg(target_family = "unix")]
+use std::os::unix::fs::MetadataExt;
 
 use crate::fs_utils::{
     self, copy_file_or_directory, delete_file_or_directory, expand_path, get_file_info,
@@ -19,6 +29,465 @@ use crate::fs_utils::{
     SymlinkResolution,
 };
 use crate::fs_watcher;
+#[cfg(target_os = "macos")]
+use crate::macos_security;
+use crate::state::{FolderSizeState, FolderSizeTaskHandle};
+
+const FOLDER_SIZE_EVENT: &str = "folder-size-progress";
+const FOLDER_SIZE_INIT_EVENT: &str = "folder-size:init";
+const FOLDER_SIZE_WINDOW_LABEL: &str = "folder-size";
+
+static FOLDER_SIZE_WINDOW_READY: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+static PENDING_FOLDER_SIZE_PAYLOAD: Lazy<Mutex<Option<FolderSizeInitPayload>>> =
+    Lazy::new(|| Mutex::new(None));
+
+fn queue_folder_size_payload(app: &AppHandle, payload: FolderSizeInitPayload) {
+    {
+        let mut pending = PENDING_FOLDER_SIZE_PAYLOAD
+            .lock()
+            .expect("Failed to lock pending folder size payload");
+        *pending = Some(payload);
+    }
+    try_emit_pending_folder_size_payload(app);
+}
+
+fn try_emit_pending_folder_size_payload(app: &AppHandle) {
+    if !FOLDER_SIZE_WINDOW_READY.load(Ordering::SeqCst) {
+        return;
+    }
+
+    let payload_opt = {
+        let mut pending = PENDING_FOLDER_SIZE_PAYLOAD
+            .lock()
+            .expect("Failed to lock pending folder size payload");
+        pending.take()
+    };
+
+    if let Some(payload) = payload_opt {
+        match app.get_webview_window(FOLDER_SIZE_WINDOW_LABEL) {
+            Some(window) => {
+                if let Err(err) = window.emit(FOLDER_SIZE_INIT_EVENT, &payload) {
+                    warn!("Failed to emit folder size init payload: {err}");
+                    let mut pending = PENDING_FOLDER_SIZE_PAYLOAD
+                        .lock()
+                        .expect("Failed to relock pending folder size payload");
+                    *pending = Some(payload);
+                } else {
+                    info!(
+                        "Emitted folder-size:init with {} targets",
+                        payload.targets.len()
+                    );
+                }
+            }
+            None => {
+                warn!("Folder size window not available for payload emission");
+                let mut pending = PENDING_FOLDER_SIZE_PAYLOAD
+                    .lock()
+                    .expect("Failed to relock pending folder size payload");
+                *pending = Some(payload);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderSizeTargetPayload {
+    pub path: String,
+    pub name: String,
+    #[serde(default)]
+    pub is_directory: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FolderSizeInitPayload {
+    request_id: String,
+    targets: Vec<FolderSizeTargetPayload>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct FolderSizeProgressPayload {
+    request_id: String,
+    total_bytes: u64,
+    total_apparent_bytes: u64,
+    total_items: u64,
+    current_path: Option<String>,
+    finished: bool,
+    cancelled: bool,
+    error: Option<String>,
+}
+
+fn emit_folder_size_event(
+    app: &AppHandle,
+    request_id: &str,
+    total_bytes: u64,
+    total_apparent_bytes: u64,
+    total_items: u64,
+    current_path: Option<String>,
+    finished: bool,
+    cancelled: bool,
+    error: Option<String>,
+) {
+    let payload = FolderSizeProgressPayload {
+        request_id: request_id.to_string(),
+        total_bytes,
+        total_apparent_bytes,
+        total_items,
+        current_path,
+        finished,
+        cancelled,
+        error,
+    };
+    if let Err(err) = app.emit(FOLDER_SIZE_EVENT, payload) {
+        warn!("Failed to emit folder size progress event: {err}");
+    }
+}
+
+const FOLDER_SIZE_EMIT_INTERVAL: Duration = Duration::from_millis(150);
+const FOLDER_SIZE_EMIT_STEP: u64 = 256;
+
+struct ProgressReporter<'a> {
+    app: &'a AppHandle,
+    request_id: &'a str,
+    last_emit: Instant,
+    items_since_emit: u64,
+    total_bytes: u64,
+    total_apparent_bytes: u64,
+    total_items: u64,
+}
+
+impl<'a> ProgressReporter<'a> {
+    fn new(app: &'a AppHandle, request_id: &'a str) -> Self {
+        let mut reporter = Self {
+            app,
+            request_id,
+            last_emit: Instant::now(),
+            items_since_emit: 0,
+            total_bytes: 0,
+            total_apparent_bytes: 0,
+            total_items: 0,
+        };
+        reporter.emit_internal(None, false, false, None);
+        reporter
+    }
+
+    fn add_file(
+        &mut self,
+        metadata: &fs::Metadata,
+        seen_inodes: &mut HashSet<(u64, u64)>,
+        current_path: Option<&Path>,
+    ) {
+        self.total_apparent_bytes = self.total_apparent_bytes.saturating_add(metadata.len());
+        let should_add_physical = match file_identity(metadata) {
+            Some(identity) => seen_inodes.insert(identity),
+            None => true,
+        };
+        if should_add_physical {
+            self.total_bytes = self
+                .total_bytes
+                .saturating_add(physical_file_size(metadata));
+        }
+        self.record_item(current_path);
+    }
+
+    fn add_entry(&mut self, current_path: Option<&Path>) {
+        self.record_item(current_path);
+    }
+
+    fn flush(&mut self, current_path: Option<&Path>) {
+        if self.items_since_emit > 0 {
+            self.emit_internal(current_path, false, false, None);
+        }
+    }
+
+    fn emit_error(&mut self, current_path: Option<&Path>, error: impl Into<String>) {
+        self.emit_internal(current_path, false, false, Some(error.into()));
+    }
+
+    fn finish(&mut self, cancelled: bool) {
+        self.emit_internal(None, true, cancelled, None);
+    }
+
+    fn totals(&self) -> (u64, u64, u64) {
+        (
+            self.total_bytes,
+            self.total_apparent_bytes,
+            self.total_items,
+        )
+    }
+
+    fn record_item(&mut self, current_path: Option<&Path>) {
+        self.total_items = self.total_items.saturating_add(1);
+        self.items_since_emit = self.items_since_emit.saturating_add(1);
+        if self.items_since_emit >= FOLDER_SIZE_EMIT_STEP
+            || self.last_emit.elapsed() >= FOLDER_SIZE_EMIT_INTERVAL
+        {
+            self.emit_internal(current_path, false, false, None);
+        }
+    }
+
+    fn emit_internal(
+        &mut self,
+        current_path: Option<&Path>,
+        finished: bool,
+        cancelled: bool,
+        error: Option<String>,
+    ) {
+        emit_folder_size_event(
+            self.app,
+            self.request_id,
+            self.total_bytes,
+            self.total_apparent_bytes,
+            self.total_items,
+            current_path.map(|p| p.to_string_lossy().to_string()),
+            finished,
+            cancelled,
+            error,
+        );
+        self.last_emit = Instant::now();
+        self.items_since_emit = 0;
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn persist_bookmark_for_scan(path: &Path) {
+    macos_security::persist_bookmark(path, "calculating folder size");
+}
+
+#[cfg(not(target_os = "macos"))]
+fn persist_bookmark_for_scan(_path: &Path) {}
+
+#[cfg(target_family = "unix")]
+fn physical_file_size(metadata: &fs::Metadata) -> u64 {
+    metadata.blocks().saturating_mul(512)
+}
+
+#[cfg(not(target_family = "unix"))]
+fn physical_file_size(metadata: &fs::Metadata) -> u64 {
+    metadata.len()
+}
+
+#[cfg(target_family = "unix")]
+fn file_identity(metadata: &fs::Metadata) -> Option<(u64, u64)> {
+    Some((metadata.dev(), metadata.ino()))
+}
+
+#[cfg(not(target_family = "unix"))]
+fn file_identity(_metadata: &fs::Metadata) -> Option<(u64, u64)> {
+    None
+}
+
+fn should_skip_path(path: &Path) -> bool {
+    // Skip cloud storage directories
+    let path_str = path.to_string_lossy().to_lowercase();
+
+    // iCloud paths
+    if path_str.contains("/library/mobile documents") || path_str.contains("library/cloudstorage") {
+        info!("Skipping iCloud path: {:?}", path);
+        return true;
+    }
+
+    // Other cloud storage
+    if path_str.contains("/onedrive")
+        || path_str.contains("/dropbox")
+        || path_str.contains("/google drive")
+        || path_str.contains("/gdrive")
+    {
+        info!("Skipping cloud storage path: {:?}", path);
+        return true;
+    }
+
+    // Skip network volumes on macOS (they typically mount under /Volumes/)
+    // but keep local external drives which also mount there
+    #[cfg(target_os = "macos")]
+    {
+        // This is a simple heuristic - network volumes often have specific patterns
+        // For more accuracy, we'd need to use system APIs to check mount type
+        if path.starts_with("/Volumes/") {
+            let volume_name = path.strip_prefix("/Volumes/").unwrap_or(path);
+            let volume_str = volume_name.to_string_lossy().to_lowercase();
+
+            // Common patterns for network mounts
+            if volume_str.starts_with("smb")
+                || volume_str.starts_with("afp")
+                || volume_str.starts_with("nfs")
+                || volume_str.contains("server")
+                || volume_str.contains("share")
+            {
+                info!("Skipping network volume: {:?}", path);
+                return true;
+            }
+        }
+
+        // Skip /System/Volumes paths except for /System/Volumes/Data which is the local disk
+        if path.starts_with("/System/Volumes/") && !path.starts_with("/System/Volumes/Data") {
+            info!("Skipping system volume: {:?}", path);
+            return true;
+        }
+    }
+
+    false
+}
+
+fn walk_paths_for_size(
+    app: &AppHandle,
+    request_id: &str,
+    roots: &[PathBuf],
+    cancel_flag: &Arc<AtomicBool>,
+) -> bool {
+    let mut reporter = ProgressReporter::new(app, request_id);
+    let mut seen_inodes: HashSet<(u64, u64)> = HashSet::new();
+
+    info!(
+        "walk_paths_for_size started with {} roots for request {}",
+        roots.len(),
+        request_id
+    );
+
+    for root in roots {
+        info!("Processing root path: {:?}", root);
+
+        if should_skip_path(root) {
+            continue;
+        }
+
+        if cancel_flag.load(Ordering::Relaxed) {
+            reporter.finish(true);
+            return true;
+        }
+
+        #[cfg(target_os = "macos")]
+        let _scope_guard = match macos_security::retain_access(root) {
+            Ok(guard) => guard,
+            Err(initial_err) => {
+                warn!(
+                    "Failed to reuse security scope for {}: {}. Attempting to refresh bookmark...",
+                    root.display(),
+                    initial_err
+                );
+
+                if let Err(store_err) = macos_security::store_bookmark_if_needed(root) {
+                    warn!(
+                        "Unable to refresh bookmark for {}: {}",
+                        root.display(),
+                        store_err
+                    );
+                    reporter.emit_error(Some(root.as_path()), initial_err);
+                    continue;
+                }
+
+                match macos_security::retain_access(root) {
+                    Ok(guard) => guard,
+                    Err(err) => {
+                        reporter.emit_error(Some(root.as_path()), err);
+                        continue;
+                    }
+                }
+            }
+        };
+
+        let symlink_meta = match fs::symlink_metadata(root) {
+            Ok(meta) => meta,
+            Err(err) => {
+                reporter.emit_error(
+                    Some(root.as_path()),
+                    format!("Failed to access entry: {err}"),
+                );
+                continue;
+            }
+        };
+
+        let is_symlink = symlink_meta.file_type().is_symlink();
+        let mut target_metadata: Option<fs::Metadata> = None;
+
+        if is_symlink {
+            match fs::metadata(root) {
+                Ok(meta) => {
+                    target_metadata = Some(meta);
+                    if let Ok(resolved) = fs::canonicalize(root) {
+                        if should_skip_path(&resolved) {
+                            info!("Skipping symlink target path: {:?}", resolved);
+                            continue;
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!("Failed to resolve symlink target for {:?}: {}", root, err);
+                    reporter.add_entry(Some(root.as_path()));
+                    persist_bookmark_for_scan(root);
+                    continue;
+                }
+            }
+        }
+
+        let metadata = target_metadata.as_ref().unwrap_or(&symlink_meta);
+
+        if metadata.is_file() {
+            reporter.add_file(metadata, &mut seen_inodes, Some(root.as_path()));
+            persist_bookmark_for_scan(root);
+            continue;
+        }
+
+        if metadata.is_dir() {
+            info!("Starting directory walk for {:?}", root);
+            let walker = WalkDir::new(root).follow_links(false).into_iter();
+            for entry in walker {
+                if cancel_flag.load(Ordering::Relaxed) {
+                    reporter.finish(true);
+                    return true;
+                }
+
+                let entry = match entry {
+                    Ok(value) => value,
+                    Err(err) => {
+                        warn!("Failed to traverse directory {:?}: {err}", root);
+                        continue;
+                    }
+                };
+
+                let entry_path = entry.path();
+                let file_type = entry.file_type();
+                let metadata = match entry.metadata() {
+                    Ok(meta) => meta,
+                    Err(err) => {
+                        warn!("Failed to read metadata for {:?}: {err}", entry_path);
+                        continue;
+                    }
+                };
+
+                if file_type.is_symlink() {
+                    reporter.add_entry(Some(entry_path));
+                } else if metadata.is_file() {
+                    reporter.add_file(&metadata, &mut seen_inodes, Some(entry_path));
+                } else {
+                    reporter.add_entry(Some(entry_path));
+                }
+            }
+
+            reporter.flush(Some(root.as_path()));
+            persist_bookmark_for_scan(root);
+            continue;
+        }
+
+        if is_symlink {
+            reporter.add_entry(Some(root.as_path()));
+            persist_bookmark_for_scan(root);
+            continue;
+        }
+
+        persist_bookmark_for_scan(root);
+    }
+
+    let (total_bytes, total_apparent_bytes, total_items) = reporter.totals();
+    info!(
+        "Folder size calculation completed. Physical bytes: {}, Logical bytes: {}, Total items: {}",
+        total_bytes, total_apparent_bytes, total_items
+    );
+    reporter.finish(false);
+    false
+}
 
 #[command]
 pub fn get_home_directory() -> Result<String, String> {
@@ -701,30 +1170,102 @@ pub fn new_window(app: AppHandle, path: Option<String>) -> Result<(), String> {
         url = tauri::WebviewUrl::App(format!("index.html?path={}", encoded_path).into());
     }
 
-    let builder = tauri::WebviewWindowBuilder::new(&app, &window_label, url)
+    let mut builder = tauri::WebviewWindowBuilder::new(&app, &window_label, url)
         .title("")
         .inner_size(1200.0, 800.0)
         .resizable(true)
-        .fullscreen(false);
+        .fullscreen(false)
+        .decorations(true);
 
     #[cfg(target_os = "macos")]
-    let builder = builder.title_bar_style(tauri::TitleBarStyle::Overlay);
+    {
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true)
+            .traffic_light_position(tauri::LogicalPosition::new(18.0, 18.0));
+    }
 
-    let window = builder
+    let _window = builder
         .build()
         .map_err(|e| format!("Failed to create window: {}", e))?;
 
+    Ok(())
+}
+
+#[command]
+pub fn open_folder_size_window(
+    app: AppHandle,
+    targets: Vec<FolderSizeTargetPayload>,
+) -> Result<(), String> {
+    if targets.is_empty() {
+        return Err("At least one directory must be selected".to_string());
+    }
+
+    if !targets.iter().any(|target| target.is_directory) {
+        return Err("Folder size requires at least one directory".to_string());
+    }
+
+    let mut unique = HashSet::new();
+    let deduped: Vec<_> = targets
+        .into_iter()
+        .filter(|target| unique.insert(target.path.clone()))
+        .collect();
+
+    let request_id = Uuid::new_v4().to_string();
+
+    let url = tauri::WebviewUrl::App("index.html?view=folder-size".into());
+
+    let payload = FolderSizeInitPayload {
+        request_id: request_id.clone(),
+        targets: deduped,
+    };
+
+    if let Some(existing) = app.get_webview_window(FOLDER_SIZE_WINDOW_LABEL) {
+        queue_folder_size_payload(&app, payload.clone());
+        let _ = existing.show();
+        let _ = existing.set_focus();
+        return Ok(());
+    }
+
+    let mut builder = tauri::WebviewWindowBuilder::new(&app, FOLDER_SIZE_WINDOW_LABEL, url)
+        .title("Folder Size")
+        .inner_size(420.0, 420.0)
+        .resizable(false)
+        .fullscreen(false)
+        .minimizable(false)
+        .maximizable(false)
+        .closable(true)
+        .decorations(true);
+
     #[cfg(target_os = "macos")]
     {
-        use tauri_plugin_decorum::WebviewWindowExt;
-        let _ = window.set_traffic_lights_inset(16.0, 24.0);
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true)
+            .traffic_light_position(tauri::LogicalPosition::new(18.0, 18.0));
     }
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = window;
-    }
+    FOLDER_SIZE_WINDOW_READY.store(false, Ordering::SeqCst);
 
+    let _window = builder
+        .build()
+        .map_err(|e| format!("Failed to create folder size window: {}", e))?;
+
+    queue_folder_size_payload(&app, payload);
+
+    Ok(())
+}
+
+#[command]
+pub fn folder_size_window_ready(app: AppHandle) -> Result<(), String> {
+    FOLDER_SIZE_WINDOW_READY.store(true, Ordering::SeqCst);
+    try_emit_pending_folder_size_payload(&app);
+    Ok(())
+}
+
+#[command]
+pub fn folder_size_window_unready() -> Result<(), String> {
+    FOLDER_SIZE_WINDOW_READY.store(false, Ordering::SeqCst);
     Ok(())
 }
 
@@ -740,6 +1281,7 @@ pub fn show_native_context_menu(
     has_file_context: Option<bool>,
     file_paths: Option<Vec<String>>,
     selected_is_symlink: Option<bool>,
+    selection_has_directory: Option<bool>,
 ) -> Result<(), String> {
     // Resolve window
     let webview = if let Some(label) = window_label {
@@ -889,6 +1431,7 @@ pub fn show_native_context_menu(
     // (or explicit file paths are provided by the frontend).
     let selection_len = file_paths.as_ref().map(|v| v.len()).unwrap_or(0);
     let is_file_ctx = has_file_context.unwrap_or(false) || selection_len > 0;
+    let has_directory_selection = selection_has_directory.unwrap_or(false);
 
     let mut builder = MenuBuilder::new(&app);
     if is_file_ctx {
@@ -901,6 +1444,15 @@ pub fn show_native_context_menu(
         let copy_full_name_item = MenuItemBuilder::with_id("ctx:copy_full_name", "Copy Full Path")
             .build(&app)
             .map_err(|e| e.to_string())?;
+        let calculate_size_item = if has_directory_selection {
+            Some(
+                MenuItemBuilder::with_id("ctx:calculate_total_size", "Calculate Total Size")
+                    .build(&app)
+                    .map_err(|e| e.to_string())?,
+            )
+        } else {
+            None
+        };
 
         let reveal_item = if selected_is_symlink.unwrap_or(false) {
             Some(
@@ -915,6 +1467,9 @@ pub fn show_native_context_menu(
             .item(&rename_item)
             .item(&copy_name_item)
             .item(&copy_full_name_item);
+        if let Some(ref item) = calculate_size_item {
+            builder = builder.item(item);
+        }
         if let Some(ref item) = reveal_item {
             builder = builder.item(item);
         }
@@ -934,6 +1489,134 @@ pub fn show_native_context_menu(
     webview
         .popup_menu_at(&ctx_menu, Position::Logical(LogicalPosition { x, y }))
         .map_err(|e| e.to_string())
+}
+
+#[command]
+pub async fn calculate_folder_size(
+    app: AppHandle,
+    state: tauri::State<'_, FolderSizeState>,
+    request_id: String,
+    paths: Vec<String>,
+) -> Result<(), String> {
+    let trimmed_id = request_id.trim();
+    if trimmed_id.is_empty() {
+        return Err("request_id cannot be empty".to_string());
+    }
+    if paths.is_empty() {
+        return Err("At least one path must be provided".to_string());
+    }
+
+    let mut unique = HashSet::new();
+    let mut resolved: Vec<PathBuf> = Vec::new();
+    for raw in paths {
+        let expanded = expand_path(&raw)?;
+        let candidate = PathBuf::from(&expanded);
+        if !candidate.exists() {
+            continue;
+        }
+        if unique.insert(candidate.clone()) {
+            resolved.push(candidate);
+        }
+    }
+
+    if resolved.is_empty() {
+        return Err("None of the provided paths could be accessed".to_string());
+    }
+
+    let normalized_id = trimmed_id.to_string();
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+
+    {
+        let mut guard = state
+            .tasks
+            .lock()
+            .map_err(|_| "Failed to access folder size state".to_string())?;
+        if let Some(existing) = guard.insert(
+            normalized_id.clone(),
+            FolderSizeTaskHandle {
+                cancel_flag: cancel_flag.clone(),
+            },
+        ) {
+            existing.cancel_flag.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let app_for_task = app.clone();
+    let request_key = normalized_id.clone();
+    info!(
+        "Starting folder size calculation task for request {}",
+        request_key
+    );
+    tauri::async_runtime::spawn(async move {
+        let paths_for_task = resolved;
+        let cancel_for_task = cancel_flag;
+        let app_for_compute = app_for_task.clone();
+        let request_for_compute = request_key.clone();
+
+        info!("Spawning blocking task for {} paths", paths_for_task.len());
+        let join_result = tauri::async_runtime::spawn_blocking(move || {
+            info!(
+                "Starting walk_paths_for_size for request {}",
+                request_for_compute
+            );
+            walk_paths_for_size(
+                &app_for_compute,
+                &request_for_compute,
+                &paths_for_task,
+                &cancel_for_task,
+            )
+        })
+        .await;
+
+        if let Err(join_err) = join_result {
+            emit_folder_size_event(
+                &app_for_task,
+                &request_key,
+                0,
+                0,
+                0,
+                None,
+                true,
+                false,
+                Some(format!("Folder size task failed: {join_err}")),
+            );
+        }
+
+        {
+            let folder_state = app_for_task.state::<FolderSizeState>();
+            if let Ok(mut guard) = folder_state.tasks.lock() {
+                guard.remove(&request_key);
+            };
+        }
+    });
+
+    Ok(())
+}
+
+#[command]
+pub fn cancel_folder_size_calculation(
+    _app: AppHandle,
+    state: tauri::State<'_, FolderSizeState>,
+    request_id: String,
+) -> Result<(), String> {
+    let trimmed_id = request_id.trim();
+    if trimmed_id.is_empty() {
+        return Err("request_id cannot be empty".to_string());
+    }
+
+    let handle = {
+        let guard = state
+            .tasks
+            .lock()
+            .map_err(|_| "Failed to access folder size state".to_string())?;
+        guard.get(trimmed_id).cloned()
+    };
+
+    if let Some(task) = handle {
+        task.cancel_flag.store(true, Ordering::SeqCst);
+    }
+
+    Ok(())
 }
 
 fn preferences_path() -> Result<PathBuf, String> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1170,7 +1170,7 @@ pub fn new_window(app: AppHandle, path: Option<String>) -> Result<(), String> {
         url = tauri::WebviewUrl::App(format!("index.html?path={}", encoded_path).into());
     }
 
-    let mut builder = tauri::WebviewWindowBuilder::new(&app, &window_label, url)
+    let builder = tauri::WebviewWindowBuilder::new(&app, &window_label, url)
         .title("")
         .inner_size(1200.0, 800.0)
         .resizable(true)
@@ -1178,12 +1178,10 @@ pub fn new_window(app: AppHandle, path: Option<String>) -> Result<(), String> {
         .decorations(true);
 
     #[cfg(target_os = "macos")]
-    {
-        builder = builder
-            .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .hidden_title(true)
-            .traffic_light_position(tauri::LogicalPosition::new(18.0, 18.0));
-    }
+    let builder = builder
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true)
+        .traffic_light_position(tauri::LogicalPosition::new(18.0, 18.0));
 
     let _window = builder
         .build()
@@ -1227,7 +1225,7 @@ pub fn open_folder_size_window(
         return Ok(());
     }
 
-    let mut builder = tauri::WebviewWindowBuilder::new(&app, FOLDER_SIZE_WINDOW_LABEL, url)
+    let builder = tauri::WebviewWindowBuilder::new(&app, FOLDER_SIZE_WINDOW_LABEL, url)
         .title("Folder Size")
         .inner_size(420.0, 420.0)
         .resizable(false)
@@ -1238,12 +1236,10 @@ pub fn open_folder_size_window(
         .decorations(true);
 
     #[cfg(target_os = "macos")]
-    {
-        builder = builder
-            .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .hidden_title(true)
-            .traffic_light_position(tauri::LogicalPosition::new(18.0, 18.0));
-    }
+    let builder = builder
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true)
+        .traffic_light_position(tauri::LogicalPosition::new(18.0, 18.0));
 
     FOLDER_SIZE_WINDOW_READY.store(false, Ordering::SeqCst);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ mod plugins;
 mod state;
 mod thumbnails;
 
-use state::MenuState;
+use state::{FolderSizeState, MenuState};
 use std::sync::Mutex;
 #[cfg(target_os = "linux")]
 use std::sync::OnceLock;
@@ -97,8 +97,13 @@ pub fn run() {
             commands::clear_thumbnail_cache,
             commands::open_path,
             commands::new_window,
+            commands::open_folder_size_window,
+            commands::folder_size_window_ready,
+            commands::folder_size_window_unready,
             commands::show_native_context_menu,
             commands::update_selection_menu_state,
+            commands::calculate_folder_size,
+            commands::cancel_folder_size_calculation,
             commands::render_svg_to_png,
             commands::read_preferences,
             commands::write_preferences,
@@ -187,6 +192,8 @@ pub fn run() {
                 sort_desc_item: Mutex::new(Some(sort_order_desc_item)),
                 has_selection: Mutex::new(false),
             });
+
+            app.manage(FolderSizeState::default());
 
             Ok(())
         })

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -412,6 +412,9 @@ pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: &tauri::menu::Me
         "ctx:copy_full_name" => {
             let _ = app.emit("menu:copy_full_name", ());
         }
+        "ctx:calculate_total_size" => {
+            let _ = app.emit("menu:calculate_total_size", ());
+        }
         "ctx:rename" => {
             let _ = app.emit("menu:rename", ());
         }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,6 @@
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
 use tauri::menu::CheckMenuItem;
 
 pub struct MenuState<R: tauri::Runtime> {
@@ -17,4 +19,21 @@ pub struct MenuState<R: tauri::Runtime> {
     pub sort_desc_item: Mutex<Option<CheckMenuItem<R>>>,
     // Selection state to drive context menu enable/visibility
     pub has_selection: Mutex<bool>,
+}
+
+#[derive(Clone)]
+pub struct FolderSizeTaskHandle {
+    pub cancel_flag: Arc<AtomicBool>,
+}
+
+pub struct FolderSizeState {
+    pub tasks: Mutex<HashMap<String, FolderSizeTaskHandle>>,
+}
+
+impl Default for FolderSizeState {
+    fn default() -> Self {
+        Self {
+            tasks: Mutex::new(HashMap::new()),
+        }
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,13 @@
         "height": 800,
         "resizable": true,
         "fullscreen": false,
-        "titleBarStyle": "Overlay"
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 18,
+          "y": 18
+        }
       }
     ],
     "security": {

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useAppStore } from '@/store/useAppStore';
 import { invoke } from '@tauri-apps/api/core';
 import { useToastStore } from '@/store/useToastStore';
+import { openFolderSizeWindow } from '@/store/useFolderSizeStore';
 
 type SortBy = 'name' | 'size' | 'type' | 'modified';
 type SortOrder = 'asc' | 'desc';
@@ -93,6 +94,7 @@ export default function ContextMenu({ x, y, isFileContext, onRequestClose }: Con
       .filter((file): file is (typeof files)[number] => Boolean(file));
   }, [fileSpecific, files, selectedFiles]);
 
+  const hasDirectorySelection = selectedFileItems.some((file) => file.is_directory);
   const singleSymlink =
     selectedFileItems.length === 1 && selectedFileItems[0]?.is_symlink
       ? selectedFileItems[0]
@@ -138,6 +140,23 @@ export default function ContextMenu({ x, y, isFileContext, onRequestClose }: Con
             >
               Copy Full Path
             </button>
+            {hasDirectorySelection && (
+              <button
+                className="w-full text-left px-3 py-2 hover:bg-app-light"
+                onClick={() => {
+                  void openFolderSizeWindow(
+                    selectedFileItems.map((item) => ({
+                      path: item.path,
+                      name: item.name,
+                      isDirectory: item.is_directory,
+                    }))
+                  );
+                  onRequestClose();
+                }}
+              >
+                Calculate Total Size
+              </button>
+            )}
             {singleSymlink && (
               <button
                 className="w-full text-left px-3 py-2 hover:bg-app-light"

--- a/src/components/MainPanel.tsx
+++ b/src/components/MainPanel.tsx
@@ -66,6 +66,7 @@ export default function MainPanel() {
       // If right-clicked a file, ensure it is selected and pass it explicitly
       let filePaths: string[] | undefined;
       let selectedIsSymlink: boolean | undefined;
+      let selectionHasDirectory = false;
       if (isFileCtx && ctxPath) {
         if (!state.selectedFiles.includes(ctxPath)) {
           setSelectedFiles([ctxPath]);
@@ -75,10 +76,13 @@ export default function MainPanel() {
           filePaths = state.selectedFiles;
         }
         const activeSelection = filePaths ?? state.selectedFiles;
-        if (activeSelection && activeSelection.length === 1) {
-          const map = new Map(state.files.map((f) => [f.path, f]));
-          const file = map.get(activeSelection[0]);
-          selectedIsSymlink = file?.is_symlink ?? false;
+        const map = new Map(state.files.map((f) => [f.path, f]));
+        if (activeSelection && activeSelection.length > 0) {
+          selectionHasDirectory = activeSelection.some((path) => map.get(path)?.is_directory);
+          if (activeSelection.length === 1) {
+            const file = map.get(activeSelection[0]);
+            selectedIsSymlink = file?.is_symlink ?? false;
+          }
         }
       } else {
         filePaths = undefined;
@@ -98,6 +102,7 @@ export default function MainPanel() {
         // Only send file paths when clicking on a file
         filePaths: isFileCtx ? filePaths : undefined,
         selectedIsSymlink,
+        selectionHasDirectory,
       });
       return;
     } catch (error) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import FolderSizeWindow from './windows/FolderSizeWindow';
 import './index.css';
+
+const params = new URLSearchParams(window.location.search);
+const view = params.get('view');
+
+const Root = view === 'folder-size' ? FolderSizeWindow : App;
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>
 );

--- a/src/store/useFolderSizeStore.ts
+++ b/src/store/useFolderSizeStore.ts
@@ -1,0 +1,185 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+import { FolderSizeProgressPayload } from '@/types';
+
+export interface FolderSizeTarget {
+  path: string;
+  name: string;
+  isDirectory: boolean;
+}
+
+interface FolderSizeState {
+  requestId?: string;
+  targets: FolderSizeTarget[];
+  totalBytes: number;
+  totalApparentBytes: number;
+  totalItems: number;
+  startedAt?: number;
+  updatedAt?: number;
+  completedAt?: number;
+  cancelled: boolean;
+  cancelRequested: boolean;
+  isRunning: boolean;
+  error?: string;
+  lastPath?: string;
+  initializeAndStart: (requestId: string, targets: FolderSizeTarget[]) => Promise<void>;
+  applyProgress: (payload: FolderSizeProgressPayload) => void;
+  cancel: () => Promise<void>;
+  reset: () => void;
+}
+
+const INITIAL_STATE: Omit<
+  FolderSizeState,
+  'initializeAndStart' | 'applyProgress' | 'cancel' | 'reset'
+> = {
+  requestId: undefined,
+  targets: [],
+  totalBytes: 0,
+  totalApparentBytes: 0,
+  totalItems: 0,
+  startedAt: undefined,
+  updatedAt: undefined,
+  completedAt: undefined,
+  cancelled: false,
+  cancelRequested: false,
+  isRunning: false,
+  error: undefined,
+  lastPath: undefined,
+};
+
+const extractErrorMessage = (error: unknown): string => {
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const { message } = error as { message?: unknown };
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return 'Unknown error';
+  }
+};
+
+export const useFolderSizeStore = create<FolderSizeState>((set, get) => ({
+  ...INITIAL_STATE,
+
+  initializeAndStart: async (requestId, targets) => {
+    if (!requestId || !targets || targets.length === 0) {
+      return;
+    }
+
+    set({
+      ...INITIAL_STATE,
+      requestId,
+      targets,
+      isRunning: true,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    try {
+      await invoke('calculate_folder_size', {
+        requestId,
+        paths: targets.map((target) => target.path),
+      });
+    } catch (error) {
+      console.warn('Failed to start folder size calculation:', error);
+      const message = extractErrorMessage(error);
+      set({
+        isRunning: false,
+        cancelRequested: false,
+        error: message,
+        updatedAt: Date.now(),
+        completedAt: Date.now(),
+      });
+    }
+  },
+
+  applyProgress: (payload) => {
+    const { requestId } = get();
+    if (!requestId || payload.requestId !== requestId) {
+      return;
+    }
+
+    set((state) => {
+      const finished = Boolean(payload.finished);
+      const cancelled = Boolean(payload.cancelled);
+      const hasError = Boolean(payload.error);
+      const running = !finished && !cancelled && !hasError;
+
+      const next: Partial<FolderSizeState> = {
+        totalBytes: payload.totalBytes,
+        totalApparentBytes: payload.totalApparentBytes ?? payload.totalBytes,
+        totalItems: payload.totalItems,
+        updatedAt: Date.now(),
+        lastPath: payload.currentPath ?? state.lastPath,
+        isRunning: running,
+      };
+
+      if (payload.error) {
+        next.error = payload.error;
+      }
+
+      if (finished || cancelled || hasError) {
+        next.cancelled = cancelled;
+        next.cancelRequested = false;
+        next.completedAt = Date.now();
+      }
+
+      return { ...state, ...next };
+    });
+  },
+
+  cancel: async () => {
+    const { requestId, cancelRequested, isRunning } = get();
+    if (!requestId || cancelRequested || !isRunning) {
+      return;
+    }
+
+    set({ cancelRequested: true });
+    try {
+      await invoke('cancel_folder_size_calculation', { requestId });
+    } catch (error) {
+      console.warn('Failed to cancel folder size calculation:', error);
+      const message = extractErrorMessage(error);
+      set({ cancelRequested: false, error: message });
+    }
+  },
+
+  reset: () => {
+    set({ ...INITIAL_STATE });
+  },
+}));
+
+export const openFolderSizeWindow = async (targets: FolderSizeTarget[]) => {
+  if (!targets || targets.length === 0) {
+    return;
+  }
+
+  const hasDirectory = targets.some((target) => target.isDirectory);
+  if (!hasDirectory) {
+    return;
+  }
+
+  const dedup = new Map<string, FolderSizeTarget>();
+  for (const target of targets) {
+    dedup.set(target.path, target);
+  }
+
+  const payload = Array.from(dedup.values()).map((target) => ({
+    path: target.path,
+    name: target.name,
+    isDirectory: target.isDirectory,
+  }));
+
+  try {
+    await invoke('open_folder_size_window', { targets: payload });
+  } catch (error) {
+    console.warn('Failed to open folder size window:', error);
+    // TODO: Add toast notification when toast store is implemented
+    // For now, just log the error
+    console.error('Unable to open folder size window:', error);
+  }
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,3 +56,25 @@ export interface DirectoryChangeEventPayload {
   changeType: string;
   affectedFiles: string[];
 }
+
+export interface FolderSizeProgressPayload {
+  requestId: string;
+  totalBytes: number;
+  totalApparentBytes: number;
+  totalItems: number;
+  currentPath?: string | null;
+  finished: boolean;
+  cancelled: boolean;
+  error?: string | null;
+}
+
+export interface FolderSizeTargetPayload {
+  path: string;
+  name: string;
+  isDirectory: boolean;
+}
+
+export interface FolderSizeInitPayload {
+  requestId: string;
+  targets: FolderSizeTargetPayload[];
+}

--- a/src/windows/FolderSizeWindow.tsx
+++ b/src/windows/FolderSizeWindow.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useMemo } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { CheckCircle, WarningCircle, XCircle } from 'phosphor-react';
+import { FolderSizeInitPayload, FolderSizeProgressPayload } from '@/types';
+import { useFolderSizeStore } from '@/store/useFolderSizeStore';
+
+const formatBytes = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, exponent);
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const formatNumber = (value: number): string =>
+  new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+
+const CONTAINER_TOP_PAD = '3rem';
+
+export default function FolderSizeWindow() {
+  const windowRef = getCurrentWindow();
+  const isMacPlatform = useMemo(() => /mac/i.test(navigator.userAgent), []);
+
+  const {
+    totalBytes,
+    totalApparentBytes,
+    totalItems,
+    lastPath,
+    isRunning,
+    cancelRequested,
+    cancelled,
+    error,
+    initializeAndStart,
+    applyProgress,
+    cancel,
+    reset,
+  } = useFolderSizeStore();
+
+  useEffect(() => {
+    let unlistenInit: (() => void) | undefined;
+    let unlistenProgress: (() => void) | undefined;
+
+    console.log('[FolderSizeWindow] Component mounted, setting up event listeners...');
+
+    (async () => {
+      try {
+        unlistenInit = await listen<FolderSizeInitPayload>('folder-size:init', async (event) => {
+          console.log('[FolderSizeWindow] Received folder-size:init event:', event.payload);
+          if (!event.payload) {
+            console.warn('[FolderSizeWindow] Event payload is empty');
+            return;
+          }
+          reset();
+          const { requestId, targets: payloadTargets } = event.payload;
+          console.log(
+            `[FolderSizeWindow] Starting calculation for ${payloadTargets.length} targets`
+          );
+          await initializeAndStart(
+            requestId,
+            payloadTargets.map((target) => ({
+              path: target.path,
+              name: target.name,
+              isDirectory: target.isDirectory,
+            }))
+          );
+        });
+        console.log('[FolderSizeWindow] Successfully set up folder-size:init listener');
+      } catch (initError) {
+        console.warn('Failed to listen for folder size init event:', initError);
+      }
+
+      try {
+        unlistenProgress = await listen<FolderSizeProgressPayload>(
+          'folder-size-progress',
+          (event) => {
+            if (event.payload) {
+              console.log(
+                '[FolderSizeWindow] Progress update:',
+                event.payload.totalBytes,
+                'physical bytes,',
+                event.payload.totalApparentBytes,
+                'logical bytes,',
+                event.payload.totalItems,
+                'items'
+              );
+              applyProgress(event.payload);
+            }
+          }
+        );
+        console.log('[FolderSizeWindow] Successfully set up folder-size-progress listener');
+      } catch (progressError) {
+        console.warn('Failed to listen for progress events:', progressError);
+      }
+    })();
+
+    return () => {
+      if (unlistenInit) {
+        unlistenInit();
+      }
+      if (unlistenProgress) {
+        unlistenProgress();
+      }
+      reset();
+    };
+  }, [initializeAndStart, applyProgress, reset, isMacPlatform]);
+
+  useEffect(() => {
+    void invoke('folder_size_window_ready').catch((error) => {
+      console.warn('Failed to notify folder size readiness:', error);
+    });
+    return () => {
+      void invoke('folder_size_window_unready').catch((error) => {
+        console.warn('Failed to reset folder size readiness:', error);
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (isRunning && !cancelRequested) {
+          void cancel();
+        }
+        void windowRef.close();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [windowRef, isRunning, cancelRequested, cancel]);
+
+  const statusIndicator = () => {
+    if (error) {
+      return (
+        <div className="flex items-center gap-2 text-sm text-red-400">
+          <WarningCircle className="h-5 w-5" weight="fill" />
+          <span>{error}</span>
+        </div>
+      );
+    }
+    if (cancelled) {
+      return (
+        <div className="flex items-center gap-2 text-sm text-white/60">
+          <XCircle className="h-5 w-5" weight="fill" />
+          <span>Scan cancelled</span>
+        </div>
+      );
+    }
+    if (isRunning) {
+      return (
+        <div className="flex items-center gap-2 text-sm text-white/70">
+          <div
+            className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-transparent"
+            aria-hidden
+          />
+          <span>{cancelRequested ? 'Cancelling…' : 'Scanning directories…'}</span>
+        </div>
+      );
+    }
+    return (
+      <div className="flex items-center gap-2 text-sm text-emerald-400">
+        <CheckCircle className="h-5 w-5" weight="fill" />
+        <span>Scan completed</span>
+      </div>
+    );
+  };
+
+  const sharedBytes = Math.max(totalApparentBytes - totalBytes, 0);
+  const hasSharedBytes = sharedBytes > 0;
+
+  return (
+    <div className="min-h-screen bg-app-dark text-app-text">
+      <div
+        className="relative mx-auto flex h-full max-w-lg flex-col gap-6 px-6 pb-10"
+        style={{ paddingTop: CONTAINER_TOP_PAD }}
+      >
+        <div data-tauri-drag-region className="absolute inset-x-2 top-0 h-12 rounded-lg" />
+        <div className="absolute inset-x-0 top-0 h-12 flex items-center justify-center pointer-events-none">
+          <span className="text-sm font-medium text-white/90">Folder Size</span>
+        </div>
+
+        <section className="space-y-3 rounded-xl border border-white/10 bg-[rgba(34,34,36,0.92)] p-6 shadow-[0_24px_70px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between text-sm text-white/80">
+            <span>Space on disk</span>
+            <span className="font-medium text-white">
+              {formatBytes(totalBytes)} ({formatNumber(totalBytes)} B)
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-sm text-white/80">
+            <span>Logical size</span>
+            <span className="font-medium text-white">
+              {formatBytes(totalApparentBytes)} ({formatNumber(totalApparentBytes)} B)
+            </span>
+          </div>
+          {hasSharedBytes ? (
+            <div className="flex items-center justify-between text-xs text-white/60">
+              <span>Shared / sparse data</span>
+              <span className="font-medium text-white/70">
+                {formatBytes(sharedBytes)} ({formatNumber(sharedBytes)} B)
+              </span>
+            </div>
+          ) : null}
+          <div className="flex items-center justify-between text-sm text-white/80">
+            <span>Items scanned</span>
+            <span className="font-medium text-white">{formatNumber(totalItems)}</span>
+          </div>
+          {lastPath ? (
+            <div className="truncate text-xs text-white/50">
+              <span className="uppercase tracking-wide text-[10px] text-white/50">Last path:</span>
+              <div className="truncate" title={lastPath}>
+                {lastPath}
+              </div>
+            </div>
+          ) : null}
+          {statusIndicator()}
+        </section>
+
+        <footer className="flex flex-wrap items-center justify-end gap-2">
+          {isRunning || cancelRequested ? (
+            <button
+              type="button"
+              onClick={() => {
+                if (!cancelRequested) {
+                  void cancel();
+                }
+              }}
+              className="rounded-md bg-white/10 px-3 py-2 text-sm text-white transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={cancelRequested}
+            >
+              {cancelRequested ? 'Cancelling…' : 'Cancel'}
+            </button>
+          ) : null}
+        </footer>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated FolderSizeWindow that streams progress updates and displays totals for selected directories
- introduce a Zustand folder size store to launch, track, and cancel size calculations through new Tauri commands
- wire the app shell, context menu, and main panel actions to launch the folder size modal when a directory is selected
- expand the Tauri backend with folder size calculation, cancellation, and window registration updates

## Testing
- npm run check

## Related Issues
- Resolves #29 (https://github.com/StirlingMarketingGroup/marlin/issues/29)
