### PR TITLE
feat: surface git status in footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
         "@tauri-apps/plugin-fs": "^2.0.0",
+        "@tauri-apps/plugin-opener": "^2.0.0",
         "@tauri-apps/plugin-os": "^2.0.0",
         "@tauri-apps/plugin-shell": "^2.0.0",
         "clsx": "^2.1.1",
@@ -53,7 +54,7 @@
         "tailwindcss": "^4.1.13",
         "typescript": "^5.6.2",
         "typescript-eslint": "^8.44.0",
-        "vite": "^7.1.5",
+        "vite": "7.1.5",
         "vitest": "^3.2.4"
       }
     },
@@ -2298,6 +2299,15 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.2.tgz",
       "integrity": "sha512-YGhmYuTgXGsi6AjoV+5mh2NvicgWBfVJHHheuck6oHD+HC9bVWPaHvCP0/Aw4pHDejwrvT8hE3+zZAaWf+hrig==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz",
+      "integrity": "sha512-B0LShOYae4CZjN8leiNDbnfjSrTwoZakqKaWpfoH6nXiJwt6Rgj6RnVIffG3DoJiKsffRhMkjmBV9VeilSb4TA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
@@ -7584,9 +7594,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.6.tgz",
-      "integrity": "sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tauri-apps/plugin-fs": "^2.0.0",
     "@tauri-apps/plugin-os": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",
+    "@tauri-apps/plugin-opener": "^2.0.0",
     "clsx": "^2.1.1",
     "phosphor-react": "^1.4.1",
     "react": "^19.1.1",
@@ -84,7 +85,7 @@
     "tailwindcss": "^4.1.13",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.44.0",
-    "vite": "^7.1.5",
+    "vite": "7.1.5",
     "vitest": "^3.2.4"
   }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ tauri-plugin-decorum = "1.1.1"
 tauri-plugin-dialog = "2.4.0"
 tauri-plugin-drag = "2.1.0"
 tauri-plugin-opener = "2.5.0"
+git2 = { version = "0.18", default-features = false, features = ["https", "vendored-openssl"] }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0"
 tokio = { version = "1.0", features = ["full"] }
@@ -48,6 +49,7 @@ rayon = "1.10"
 uuid = { version = "1.0", features = ["v4"] }
 sha2 = "0.10"
 urlencoding = "2.1"
+url = "2.5"
 webp = { version = "0.3", optional = true }
 once_cell = "1.19"
 num_cpus = "1.16"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
     "core:window:allow-start-dragging",
     "dialog:default",
     "shell:allow-open",
+    "opener:allow-open-url",
+    "opener:allow-reveal-item-in-dir",
     "core:window:allow-minimize",
     "core:window:allow-maximize",
     "core:window:allow-unmaximize",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,6 +77,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::get_home_directory,
             commands::get_disk_usage,
+            commands::get_git_status,
             commands::read_directory,
             commands::get_file_metadata,
             commands::resolve_symlink_parent_command,

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { useAppStore } from '@/store/useAppStore';
 import type { DiskUsage } from '@/types';
+import { ArrowSquareOut } from 'phosphor-react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 
 // Cache per-path disk usage responses briefly so we avoid hammering the backend while
 // navigating through the same directory.
@@ -52,6 +54,9 @@ export default function StatusBar() {
   const loading = useAppStore((state) => state.loading);
   const globalPreferences = useAppStore((state) => state.globalPreferences);
   const directoryPreferences = useAppStore((state) => state.directoryPreferences);
+  const gitStatus = useAppStore((state) => state.gitStatus);
+  const gitStatusLoading = useAppStore((state) => state.gitStatusLoading);
+  const gitStatusError = useAppStore((state) => state.gitStatusError);
 
   const numberFormatter = useMemo(
     () => new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }),
@@ -172,6 +177,162 @@ export default function StatusBar() {
     };
   }, [diskUsage, diskError, diskLoading]);
 
+  const handleOpenRemote = useCallback(async () => {
+    const targetUrl = gitStatus?.remoteBranchUrl ?? gitStatus?.remoteUrl;
+    if (!targetUrl) {
+      return;
+    }
+
+    try {
+      await openUrl(targetUrl);
+    } catch (primaryError) {
+      try {
+        await invoke('open_path', { path: targetUrl });
+      } catch (fallbackError) {
+        console.warn('Failed to open remote repository:', primaryError, fallbackError);
+      }
+    }
+  }, [gitStatus?.remoteBranchUrl, gitStatus?.remoteUrl]);
+
+  const gitSegment = useMemo(() => {
+    if (gitStatusLoading) {
+      return (
+        <div className="flex items-baseline gap-1 text-xs text-app-muted">
+          <span>Git</span>
+          <span className="text-app-text font-medium">Checking...</span>
+        </div>
+      );
+    }
+
+    if (gitStatusError) {
+      return (
+        <div className="flex items-baseline gap-1 text-xs text-app-muted" title={gitStatusError}>
+          <span>Git</span>
+          <span className="text-amber-400 font-medium">Unavailable</span>
+        </div>
+      );
+    }
+
+    if (!gitStatus) {
+      return null;
+    }
+
+    const branchLabel = gitStatus.detached
+      ? gitStatus.branch
+        ? `detached @ ${gitStatus.branch}`
+        : 'detached HEAD'
+      : (gitStatus.branch ?? 'HEAD');
+
+    const remoteHost = (() => {
+      if (!gitStatus.remoteUrl) return null;
+      try {
+        return new URL(gitStatus.remoteUrl).host;
+      } catch (error) {
+        console.warn('Failed to parse remote URL host:', error);
+        return gitStatus.remoteUrl.replace(/^https?:\/\//i, '');
+      }
+    })();
+
+    const indicatorItems: ReactNode[] = [];
+    const hasDirtyChanges = gitStatus.dirty || gitStatus.hasUntracked;
+    const dirtyTitle = hasDirtyChanges
+      ? [
+          gitStatus.dirty ? 'Working tree has staged or unstaged changes' : null,
+          gitStatus.hasUntracked ? 'Untracked files present' : null,
+        ]
+          .filter(Boolean)
+          .join('. ')
+      : 'Working tree clean';
+
+    indicatorItems.push(
+      <span
+        key="dirty"
+        className={`flex items-center gap-1 text-xs ${
+          hasDirtyChanges ? 'text-amber-400' : 'text-emerald-400'
+        }`}
+        title={dirtyTitle}
+      >
+        <span aria-hidden className="inline-flex h-2 w-2 rounded-full bg-current" />
+        <span>{hasDirtyChanges ? 'Dirty' : 'Clean'}</span>
+      </span>
+    );
+
+    if (gitStatus.ahead > 0) {
+      indicatorItems.push(
+        <span
+          key="ahead"
+          className="flex items-center gap-1 text-xs text-emerald-400"
+          title={`Ahead of upstream by ${gitStatus.ahead} commit${gitStatus.ahead === 1 ? '' : 's'}`}
+        >
+          <span aria-hidden>+</span>
+          <span>{gitStatus.ahead}</span>
+        </span>
+      );
+    }
+
+    if (gitStatus.behind > 0) {
+      indicatorItems.push(
+        <span
+          key="behind"
+          className="flex items-center gap-1 text-xs text-rose-400"
+          title={`Behind upstream by ${gitStatus.behind} commit${gitStatus.behind === 1 ? '' : 's'}`}
+        >
+          <span aria-hidden>-</span>
+          <span>{gitStatus.behind}</span>
+        </span>
+      );
+    }
+
+    const branchTitle = `Repository: ${gitStatus.repositoryRoot}`;
+
+    const targetUrl = gitStatus.remoteBranchUrl ?? gitStatus.remoteUrl;
+
+    const branchNode = targetUrl ? (
+      <button
+        type="button"
+        onClick={handleOpenRemote}
+        className="text-app-text font-medium transition-colors hover:text-app-text/90 focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-300/40"
+        title={`${branchTitle}\nClick to open remote`}
+      >
+        {branchLabel}
+      </button>
+    ) : (
+      <span className="text-app-text font-medium" title={branchTitle}>
+        {branchLabel}
+      </span>
+    );
+
+    const remoteLabel = remoteHost === 'github.com' ? 'GitHub' : (remoteHost ?? 'Remote');
+
+    const remoteButton = targetUrl ? (
+      <button
+        type="button"
+        onClick={handleOpenRemote}
+        className="inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[11px] font-medium text-app-muted transition-colors hover:text-app-text focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-300/40"
+        title={`Open ${targetUrl}`}
+        aria-label={`Open remote ${remoteHost ?? 'repository'} in browser`}
+      >
+        <span>{remoteLabel}</span>
+        <ArrowSquareOut size={12} weight="bold" />
+      </button>
+    ) : null;
+
+    return (
+      <div className="flex items-baseline gap-1 text-xs text-app-muted">
+        <span>Git</span>
+        <div className="flex items-center gap-2 text-app-text font-medium">
+          {branchNode}
+          {remoteButton}
+          {indicatorItems.length > 0 ? (
+            <div className="flex items-center gap-2 text-xs font-normal text-app-muted/90">
+              {indicatorItems}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  }, [gitStatus, gitStatusError, gitStatusLoading, handleOpenRemote]);
+
   return (
     <div className="pointer-events-auto border border-app-border/70 border-b-0 border-r-0 bg-app-darker/90 px-4 py-2 text-xs rounded-tl-lg backdrop-blur">
       <div className="flex flex-wrap items-center gap-4">
@@ -188,6 +349,7 @@ export default function StatusBar() {
           value={loading && files.length === 0 ? '...' : formatBytes(stats.totalSize)}
           title={`${formatBytes(stats.totalSize)} (${numberFormatter.format(stats.totalSize)} B)`}
         />
+        {gitSegment}
         <div className="flex items-baseline gap-1 text-xs text-app-muted">
           <span>Disk</span>
           {typeof diskSummary === 'string' ? (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,18 @@ export interface DiskUsage {
   availableBytes: number;
 }
 
+export interface GitStatus {
+  repositoryRoot: string;
+  branch?: string;
+  detached: boolean;
+  ahead: number;
+  behind: number;
+  dirty: boolean;
+  hasUntracked: boolean;
+  remoteUrl?: string;
+  remoteBranchUrl?: string;
+}
+
 export interface PinnedDirectory {
   name: string;
   path: string;


### PR DESCRIPTION
## Summary
- add async git status command with branch/ahead/behind info and remote link detection
- surface cached git status in store and render footer segment with remote link
- normalize remote branch URLs for GitHub, GitLab, Bitbucket and open via existing command

## Testing
- npm run typecheck
- cargo check

Closes #31