### PR TITLE
perf: prewarm thumbnail worker

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
             commands::update_sort_menu_state,
             commands::get_system_drives,
             commands::eject_drive,
+            commands::initialize_thumbnail_service,
             commands::request_thumbnail,
             commands::cancel_thumbnail,
             commands::get_thumbnail_cache_stats,


### PR DESCRIPTION
## Summary
- prewarm the thumbnail worker during app initialization so the first grid load avoids worker spin-up latency
- expose a dedicated initialize command that logs timing and short-circuits when already running
- emit a dev-only console log to confirm prewarm timing

## Testing
- npm run lint -- src/App.tsx
- cargo check

Closes #42