### PR TITLE
feat: use accent color in STL thumbnails

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1380,6 +1380,7 @@ pub async fn request_thumbnail(
     quality: Option<String>,
     priority: Option<String>,
     format: Option<String>,
+    accent: Option<crate::thumbnails::AccentColor>,
 ) -> Result<crate::thumbnails::ThumbnailResponse, String> {
     let service = get_thumbnail_service().await?;
 
@@ -1408,6 +1409,7 @@ pub async fn request_thumbnail(
         quality,
         priority,
         format,
+        accent,
     };
 
     service.request_thumbnail(request).await

--- a/src-tauri/src/thumbnails/worker.rs
+++ b/src-tauri/src/thumbnails/worker.rs
@@ -153,6 +153,7 @@ impl ThumbnailWorker {
                                     .put(
                                         &request.path,
                                         request.size,
+                                        request.accent.as_ref(),
                                         data_url.clone(),
                                         generation_time_ms,
                                         has_transparency,


### PR DESCRIPTION
## Summary
- plumb the accent color through thumbnail requests, cache entries, and worker writes
- shade STL thumbnails with the requested accent while keeping a teal fallback
- detect runtime CSS accent updates on the frontend and include them in thumbnail requests

## Testing
- npm run build

Closes #41