### PR TITLE
feat: add pluggable location provider architecture

### DIFF
--- a/docs/location-providers.md
+++ b/docs/location-providers.md
@@ -1,0 +1,82 @@
+# Location Provider Architecture
+
+Marlin's filesystem commands can now operate on pluggable "location providers". The
+initial implementation continues to use the local filesystem provider (`file://`),
+but the abstraction allows future backends like `s3://`, `smb://`, or `ftp://` to
+plug in without touching command handlers.
+
+## Provider registry
+
+`src-tauri/src/locations/mod.rs` defines the core pieces:
+
+- `LocationInput` parses the path payload that comes from Tauri commands. It accepts
+  either a raw string (e.g. `/Users/me` or `s3://my-bucket/path`) or a structured
+  object with `scheme`, `authority`, and `path` fields.
+- `Location` represents the parsed result and provides helpers for building native
+  paths when the provider expects them.
+- `LocationProvider` is the trait each backend implements. It covers directory
+  listing, metadata, and basic file operations (create, delete, rename, copy, move).
+- `LocationCapabilities` communicates which operations are allowed so the frontend
+  can disable unsupported actions.
+- `ProviderDirectoryEntries` wraps the normalized `LocationSummary` plus the
+  `FileItem` list after a directory read.
+
+The static registry registers the local filesystem provider by default:
+
+```rust
+static REGISTRY: Lazy<RwLock<ProviderMap>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+    let file_provider: ProviderRef = Arc::new(FileSystemProvider::default());
+    map.insert(file_provider.scheme().to_string(), file_provider);
+    RwLock::new(map)
+});
+```
+
+`resolve_location` is used by Tauri commands to convert the inbound payload into a
+`Location` and look up the matching provider.
+
+## FileSystemProvider
+
+`src-tauri/src/locations/file.rs` contains the current `file://` provider. It
+wraps the existing helpers in `fs_utils.rs` to:
+
+- Expand the incoming path (including `~` on macOS/Linux).
+- Validate directory / file existence before acting.
+- Preserve the previous case-insensitive rename behaviour by using a two-stage
+  rename when only letter casing changes.
+- Report full capabilities (`canCopy`, `canMove`, `supportsWatching`, etc.).
+
+Future providers should follow the same pattern: resolve the raw location into a
+provider-specific native representation, implement the trait functions, and return
+a meaningful `LocationSummary` so the frontend can store a canonical URI.
+
+## Command changes
+
+`src-tauri/src/commands.rs` now accepts `LocationInput` for the core file
+operations (`read_directory`, `get_file_metadata`, `create_directory_command`,
+`delete_file`, `rename_file`, `copy_file`, `move_file`). `read_directory` returns a
+`DirectoryListingResponse` that includes both the file entries and the provider
+capabilities.
+
+Commands that still rely on direct filesystem access (e.g. disk usage, Git status,
+watchers) continue to operate on local paths and now use the normalized path from
+the provider response.
+
+## Frontend adjustments
+
+The frontend store (`src/store/useAppStore.ts`) continues to track `currentPath`
+as before but now consumes the richer `DirectoryListingResponse`. It stores the
+provider capabilities so UI surfaces can disable actions when the backend reports
+they are unavailable.
+
+## Adding a new provider
+
+1. Implement a new module in `src-tauri/src/locations/` that satisfies the
+   `LocationProvider` trait.
+2. Register it in the registry (e.g. insert under `s3` or `smb` scheme).
+3. Update the frontend to send the appropriate scheme in command invocations and
+   to respect the reported capabilities.
+4. Extend the UI as needed (auth prompts, status indicators, etc.).
+
+With these pieces in place the backend no longer assumes every path is local, and
+new protocols can be introduced incrementally without rewriting the command layer.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -28,11 +28,10 @@ use walkdir::WalkDir;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 use crate::fs_utils::{
-    self, copy_file_or_directory, delete_file_or_directory, expand_path, get_file_info,
-    read_directory_contents, rename_file_or_directory, resolve_symlink_parent, DiskUsage, FileItem,
-    SymlinkResolution,
+    self, expand_path, resolve_symlink_parent, DiskUsage, FileItem, SymlinkResolution,
 };
 use crate::fs_watcher;
+use crate::locations::{resolve_location, LocationCapabilities, LocationInput, LocationSummary};
 #[cfg(target_os = "macos")]
 use crate::macos_security;
 use crate::state::{FolderSizeState, FolderSizeTaskHandle};
@@ -49,6 +48,14 @@ const FOLDER_SIZE_WINDOW_LABEL: &str = "folder-size";
 const ARCHIVE_PROGRESS_EVENT: &str = "archive-progress:init";
 const ARCHIVE_PROGRESS_WINDOW_LABEL: &str = "archive-progress";
 const ARCHIVE_PROGRESS_UPDATE_EVENT: &str = "archive-progress:update";
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DirectoryListingResponse {
+    pub location: LocationSummary,
+    pub capabilities: LocationCapabilities,
+    pub entries: Vec<FileItem>,
+}
 
 static FOLDER_SIZE_WINDOW_READY: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 static PENDING_FOLDER_SIZE_PAYLOAD: Lazy<Mutex<Option<FolderSizeInitPayload>>> =
@@ -904,31 +911,22 @@ pub async fn get_git_status(path: String) -> Result<Option<GitStatusResponse>, S
 }
 
 #[command]
-pub fn read_directory(path: String) -> Result<Vec<FileItem>, String> {
-    let expanded_path = expand_path(&path)?;
-    let path = Path::new(&expanded_path);
+pub fn read_directory(path: LocationInput) -> Result<DirectoryListingResponse, String> {
+    let (provider, location) = resolve_location(path)?;
+    let listing = provider.read_directory(&location)?;
+    let capabilities = provider.capabilities(&location);
 
-    if !path.exists() {
-        return Err("Path does not exist".to_string());
-    }
-
-    if !path.is_dir() {
-        return Err("Path is not a directory".to_string());
-    }
-
-    read_directory_contents(path)
+    Ok(DirectoryListingResponse {
+        location: listing.location,
+        capabilities,
+        entries: listing.entries,
+    })
 }
 
 #[command]
-pub fn get_file_metadata(path: String) -> Result<FileItem, String> {
-    let expanded_path = expand_path(&path)?;
-    let path = Path::new(&expanded_path);
-
-    if !path.exists() {
-        return Err("Path does not exist".to_string());
-    }
-
-    get_file_info(path)
+pub fn get_file_metadata(path: LocationInput) -> Result<FileItem, String> {
+    let (provider, location) = resolve_location(path)?;
+    provider.get_file_metadata(&location)
 }
 
 #[command]
@@ -940,113 +938,75 @@ pub fn resolve_symlink_parent_command(path: String) -> Result<SymlinkResolution,
 }
 
 #[command]
-pub fn create_directory_command(path: String) -> Result<(), String> {
-    let expanded_path = expand_path(&path)?;
-    let path = Path::new(&expanded_path);
-
-    fs_utils::create_directory(path)
+pub fn create_directory_command(path: LocationInput) -> Result<(), String> {
+    let (provider, location) = resolve_location(path)?;
+    let capabilities = provider.capabilities(&location);
+    if !capabilities.can_create_directories {
+        return Err("Provider does not support creating directories".to_string());
+    }
+    provider.create_directory(&location)
 }
 
 #[command]
-pub fn delete_file(path: String) -> Result<(), String> {
-    let expanded_path = expand_path(&path)?;
-    let path = Path::new(&expanded_path);
-
-    if !path.exists() {
-        return Err("Path does not exist".to_string());
+pub fn delete_file(path: LocationInput) -> Result<(), String> {
+    let (provider, location) = resolve_location(path)?;
+    let capabilities = provider.capabilities(&location);
+    if !capabilities.can_delete {
+        return Err("Provider does not support deleting items".to_string());
     }
-
-    delete_file_or_directory(path)
+    provider.delete(&location)
 }
 
 #[command]
-pub fn rename_file(from_path: String, to_path: String) -> Result<(), String> {
-    let expanded_from = expand_path(&from_path)?;
-    let expanded_to = expand_path(&to_path)?;
-    let from = Path::new(&expanded_from);
-    let to = Path::new(&expanded_to);
+pub fn rename_file(from_path: LocationInput, to_path: LocationInput) -> Result<(), String> {
+    let (from_provider, from_location) = resolve_location(from_path)?;
+    let (_, to_location) = resolve_location(to_path)?;
 
-    if !from.exists() {
-        return Err("Source path does not exist".to_string());
+    if from_location.scheme() != to_location.scheme() {
+        return Err("Renaming across different providers is not supported".to_string());
     }
 
-    // Allow case-only renames on case-insensitive filesystems by using a two-step rename.
-    // If the destination exists but only differs by letter casing, perform: from -> temp -> to
-    let same_parent = from.parent() == to.parent();
-    let from_name = from.file_name().and_then(|s| s.to_str());
-    let to_name = to.file_name().and_then(|s| s.to_str());
-    let is_case_only = same_parent
-        && from_name.is_some()
-        && to_name.is_some()
-        && from_name != to_name
-        && from_name.unwrap().eq_ignore_ascii_case(to_name.unwrap());
-
-    if to.exists() && !is_case_only {
-        return Err("Destination path already exists".to_string());
+    let capabilities = from_provider.capabilities(&from_location);
+    if !capabilities.can_rename {
+        return Err("Provider does not support renaming".to_string());
     }
 
-    if is_case_only {
-        // Two-step rename to update case where FS is case-insensitive
-        let parent = from
-            .parent()
-            .ok_or_else(|| "Invalid source path".to_string())?;
-        // Generate a temporary name that shouldn't collide
-        let mut counter: u32 = 0;
-        let mut temp_path;
-        loop {
-            let ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_else(|_| std::time::Duration::from_millis(0))
-                .as_millis();
-            let temp_name = format!(".__rename_tmp_{}_{}", ts, counter);
-            temp_path = parent.join(&temp_name);
-            if !temp_path.exists() {
-                break;
-            }
-            counter += 1;
-            if counter > 1000 {
-                return Err("Failed to allocate temporary name for rename".to_string());
-            }
-        }
-
-        fs::rename(from, &temp_path).map_err(|e| format!("Failed to rename (stage 1): {}", e))?;
-        fs::rename(&temp_path, to).map_err(|e| format!("Failed to rename (stage 2): {}", e))?;
-        return Ok(());
-    }
-
-    rename_file_or_directory(from, to)
+    // When both locations share the same scheme we can rely on the source provider.
+    from_provider.rename(&from_location, &to_location)
 }
 
 #[command]
-pub fn copy_file(from_path: String, to_path: String) -> Result<(), String> {
-    let expanded_from = expand_path(&from_path)?;
-    let expanded_to = expand_path(&to_path)?;
-    let from = Path::new(&expanded_from);
-    let to = Path::new(&expanded_to);
+pub fn copy_file(from_path: LocationInput, to_path: LocationInput) -> Result<(), String> {
+    let (from_provider, from_location) = resolve_location(from_path)?;
+    let (_, to_location) = resolve_location(to_path)?;
 
-    if !from.exists() {
-        return Err("Source path does not exist".to_string());
+    if from_location.scheme() != to_location.scheme() {
+        return Err("Copying across different providers is not yet supported".to_string());
     }
 
-    copy_file_or_directory(from, to)
+    let capabilities = from_provider.capabilities(&from_location);
+    if !capabilities.can_copy {
+        return Err("Provider does not support copy operations".to_string());
+    }
+
+    from_provider.copy(&from_location, &to_location)
 }
 
 #[command]
-pub fn move_file(from_path: String, to_path: String) -> Result<(), String> {
-    let expanded_from = expand_path(&from_path)?;
-    let expanded_to = expand_path(&to_path)?;
-    let from = Path::new(&expanded_from);
-    let to = Path::new(&expanded_to);
+pub fn move_file(from_path: LocationInput, to_path: LocationInput) -> Result<(), String> {
+    let (from_provider, from_location) = resolve_location(from_path)?;
+    let (_, to_location) = resolve_location(to_path)?;
 
-    if !from.exists() {
-        return Err("Source path does not exist".to_string());
+    if from_location.scheme() != to_location.scheme() {
+        return Err("Moving across different providers is not yet supported".to_string());
     }
 
-    if to.exists() {
-        return Err("Destination path already exists".to_string());
+    let capabilities = from_provider.capabilities(&from_location);
+    if !capabilities.can_move {
+        return Err("Provider does not support move operations".to_string());
     }
 
-    rename_file_or_directory(from, to)
+    from_provider.move_item(&from_location, &to_location)
 }
 
 fn allocate_destination_folder(destination_root: &Path, base_name: &str) -> Result<String, String> {
@@ -1246,13 +1206,8 @@ fn create_tar_reader(
     archive_format: ArchiveFormat,
     archive_path: &Path,
 ) -> Result<Box<dyn Read>, String> {
-    let file = fs::File::open(archive_path).map_err(|err| {
-        format!(
-            "Failed to open archive {}: {}",
-            archive_path.display(),
-            err
-        )
-    })?;
+    let file = fs::File::open(archive_path)
+        .map_err(|err| format!("Failed to open archive {}: {}", archive_path.display(), err))?;
 
     let reader: Box<dyn Read> = match archive_format {
         ArchiveFormat::Tar => Box::new(file),
@@ -1261,11 +1216,7 @@ fn create_tar_reader(
         ArchiveFormat::TarXz => Box::new(XzDecoder::new(file)),
         ArchiveFormat::TarZst => {
             let decoder = ZstdDecoder::new(file).map_err(|err| {
-                format!(
-                    "Failed to read archive {}: {}",
-                    archive_path.display(),
-                    err
-                )
+                format!("Failed to read archive {}: {}", archive_path.display(), err)
             })?;
             Box::new(decoder)
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod fs_utils;
 mod fs_watcher;
+mod locations;
 #[cfg(target_os = "macos")]
 mod macos_icons;
 mod macos_security;

--- a/src-tauri/src/locations/file.rs
+++ b/src-tauri/src/locations/file.rs
@@ -1,0 +1,167 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::{
+    Location, LocationCapabilities, LocationProvider, LocationSummary, ProviderDirectoryEntries,
+};
+use crate::fs_utils::{
+    copy_file_or_directory, create_directory, delete_file_or_directory, expand_path, get_file_info,
+    read_directory_contents, rename_file_or_directory,
+};
+
+#[derive(Default)]
+pub struct FileSystemProvider;
+
+impl FileSystemProvider {
+    fn ensure_file_scheme<'a>(&self, location: &'a Location) -> Result<&'a Location, String> {
+        if location.scheme() != "file" {
+            return Err("FileSystemProvider only supports file:// locations".to_string());
+        }
+        Ok(location)
+    }
+
+    fn resolve_path(&self, location: &Location) -> Result<(PathBuf, LocationSummary), String> {
+        let location = self.ensure_file_scheme(location)?;
+        let raw_path = location.to_path_string();
+        let expanded = expand_path(&raw_path)?;
+        let normalized = expanded.to_string_lossy().to_string();
+        let summary = LocationSummary::new(
+            "file",
+            location.authority().map(|s| s.to_string()),
+            normalized.clone(),
+            normalized.clone(),
+        );
+        Ok((expanded, summary))
+    }
+
+    fn resolve_path_only(&self, location: &Location) -> Result<PathBuf, String> {
+        let (path, _) = self.resolve_path(location)?;
+        Ok(path)
+    }
+
+    fn two_stage_case_rename(&self, from: &Path, to: &Path) -> Result<(), String> {
+        let parent = from
+            .parent()
+            .ok_or_else(|| "Invalid source path".to_string())?;
+
+        let mut counter: u32 = 0;
+        let temp_path = loop {
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_else(|_| std::time::Duration::from_millis(0))
+                .as_millis();
+            let temp_name = format!(".__rename_tmp_{}_{}", ts, counter);
+            let candidate = parent.join(&temp_name);
+            if !candidate.exists() {
+                break candidate;
+            }
+            counter += 1;
+            if counter > 1_000 {
+                return Err("Failed to allocate temporary name for rename".to_string());
+            }
+        };
+
+        fs::rename(from, &temp_path).map_err(|e| format!("Failed to rename (stage 1): {}", e))?;
+        fs::rename(&temp_path, to).map_err(|e| format!("Failed to rename (stage 2): {}", e))?;
+        Ok(())
+    }
+}
+
+impl LocationProvider for FileSystemProvider {
+    fn scheme(&self) -> &'static str {
+        "file"
+    }
+
+    fn capabilities(&self, _location: &Location) -> LocationCapabilities {
+        LocationCapabilities::new("file", "Local Filesystem", true, true)
+            .with_supports_watching(true)
+    }
+
+    fn read_directory(&self, location: &Location) -> Result<ProviderDirectoryEntries, String> {
+        let (path, summary) = self.resolve_path(location)?;
+
+        if !path.exists() {
+            return Err("Path does not exist".to_string());
+        }
+        if !path.is_dir() {
+            return Err("Path is not a directory".to_string());
+        }
+
+        let entries = read_directory_contents(&path)?;
+
+        Ok(ProviderDirectoryEntries {
+            location: summary,
+            entries,
+        })
+    }
+
+    fn get_file_metadata(&self, location: &Location) -> Result<crate::fs_utils::FileItem, String> {
+        let path = self.resolve_path_only(location)?;
+        if !path.exists() {
+            return Err("Path does not exist".to_string());
+        }
+        get_file_info(&path)
+    }
+
+    fn create_directory(&self, location: &Location) -> Result<(), String> {
+        let path = self.resolve_path_only(location)?;
+        create_directory(&path)
+    }
+
+    fn delete(&self, location: &Location) -> Result<(), String> {
+        let path = self.resolve_path_only(location)?;
+        if !path.exists() {
+            return Err("Path does not exist".to_string());
+        }
+        delete_file_or_directory(&path)
+    }
+
+    fn rename(&self, from: &Location, to: &Location) -> Result<(), String> {
+        let from_path = self.resolve_path_only(from)?;
+        if !from_path.exists() {
+            return Err("Source path does not exist".to_string());
+        }
+
+        let to_path = self.resolve_path_only(to)?;
+
+        let same_parent = from_path.parent() == to_path.parent();
+        let from_name = from_path.file_name().and_then(|s| s.to_str());
+        let to_name = to_path.file_name().and_then(|s| s.to_str());
+        let is_case_only = same_parent
+            && from_name.is_some()
+            && to_name.is_some()
+            && from_name.unwrap().ne(to_name.unwrap())
+            && from_name.unwrap().eq_ignore_ascii_case(to_name.unwrap());
+
+        if to_path.exists() && !is_case_only {
+            return Err("Destination path already exists".to_string());
+        }
+
+        if is_case_only {
+            return self.two_stage_case_rename(&from_path, &to_path);
+        }
+
+        rename_file_or_directory(&from_path, &to_path)
+    }
+
+    fn copy(&self, from: &Location, to: &Location) -> Result<(), String> {
+        let from_path = self.resolve_path_only(from)?;
+        if !from_path.exists() {
+            return Err("Source path does not exist".to_string());
+        }
+        let to_path = self.resolve_path_only(to)?;
+        copy_file_or_directory(&from_path, &to_path)
+    }
+
+    fn move_item(&self, from: &Location, to: &Location) -> Result<(), String> {
+        let from_path = self.resolve_path_only(from)?;
+        if !from_path.exists() {
+            return Err("Source path does not exist".to_string());
+        }
+        let to_path = self.resolve_path_only(to)?;
+        if to_path.exists() {
+            return Err("Destination path already exists".to_string());
+        }
+        rename_file_or_directory(&from_path, &to_path)
+    }
+}

--- a/src-tauri/src/locations/mod.rs
+++ b/src-tauri/src/locations/mod.rs
@@ -1,0 +1,324 @@
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, RwLock};
+
+use crate::fs_utils::FileItem;
+
+mod file;
+
+pub use file::FileSystemProvider;
+
+pub type ProviderRef = Arc<dyn LocationProvider + Send + Sync>;
+
+type ProviderMap = HashMap<String, ProviderRef>;
+
+static REGISTRY: Lazy<RwLock<ProviderMap>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+    let file_provider: ProviderRef = Arc::new(FileSystemProvider::default());
+    map.insert(file_provider.scheme().to_string(), file_provider);
+    RwLock::new(map)
+});
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationSummary {
+    pub raw: String,
+    pub scheme: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority: Option<String>,
+    pub path: String,
+    pub display_path: String,
+}
+
+impl LocationSummary {
+    pub fn new(
+        scheme: impl Into<String>,
+        authority: Option<String>,
+        path: impl Into<String>,
+        display_path: impl Into<String>,
+    ) -> Self {
+        let scheme = scheme.into();
+        let path = path.into();
+        let display_path = display_path.into();
+        let raw = compose_raw_uri(&scheme, authority.as_deref(), &path);
+        Self {
+            raw,
+            scheme,
+            authority,
+            path,
+            display_path,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationCapabilities {
+    pub scheme: String,
+    pub display_name: String,
+    pub can_read: bool,
+    pub can_write: bool,
+    pub can_create_directories: bool,
+    pub can_delete: bool,
+    pub can_rename: bool,
+    pub can_copy: bool,
+    pub can_move: bool,
+    pub supports_watching: bool,
+    pub requires_explicit_refresh: bool,
+}
+
+impl LocationCapabilities {
+    pub fn new(
+        scheme: impl Into<String>,
+        display_name: impl Into<String>,
+        can_read: bool,
+        can_write: bool,
+    ) -> Self {
+        Self {
+            scheme: scheme.into(),
+            display_name: display_name.into(),
+            can_read,
+            can_write,
+            can_create_directories: can_write,
+            can_delete: can_write,
+            can_rename: can_write,
+            can_copy: can_write,
+            can_move: can_write,
+            supports_watching: false,
+            requires_explicit_refresh: false,
+        }
+    }
+
+    pub fn with_supports_watching(mut self, supports: bool) -> Self {
+        self.supports_watching = supports;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationDescriptorInput {
+    #[serde(default)]
+    pub scheme: Option<String>,
+    #[serde(default)]
+    pub authority: Option<String>,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum LocationInput {
+    Raw(String),
+    Descriptor(LocationDescriptorInput),
+}
+
+#[derive(Debug, Clone)]
+pub struct Location {
+    scheme: String,
+    authority: Option<String>,
+    path: String,
+    raw: String,
+}
+
+impl Location {
+    pub fn scheme(&self) -> &str {
+        &self.scheme
+    }
+
+    pub fn authority(&self) -> Option<&str> {
+        self.authority.as_deref()
+    }
+
+    pub fn to_path_string(&self) -> String {
+        if let Some(authority) = &self.authority {
+            let mut path = String::from("//");
+            path.push_str(authority);
+            if self.path.starts_with('/') {
+                path.push_str(&self.path);
+            } else {
+                path.push('/');
+                path.push_str(&self.path);
+            }
+            path
+        } else if self.path.is_empty() {
+            "/".to_string()
+        } else {
+            self.path.clone()
+        }
+    }
+}
+
+impl fmt::Display for Location {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.raw)
+    }
+}
+
+fn compose_raw_uri(scheme: &str, authority: Option<&str>, path: &str) -> String {
+    let mut raw = format!("{scheme}://");
+    if let Some(host) = authority {
+        raw.push_str(host);
+    }
+    if !path.starts_with('/') {
+        raw.push('/');
+    }
+    raw.push_str(path);
+    raw
+}
+
+impl LocationInput {
+    pub fn into_location(self) -> Result<Location, String> {
+        match self {
+            LocationInput::Raw(value) => parse_raw_location(value),
+            LocationInput::Descriptor(descriptor) => {
+                let scheme = descriptor
+                    .scheme
+                    .unwrap_or_else(|| "file".to_string())
+                    .to_ascii_lowercase();
+                let authority = descriptor.authority.filter(|s| !s.is_empty());
+                let path = sanitize_path(descriptor.path);
+                let raw = compose_raw_uri(&scheme, authority.as_deref(), &path);
+                Ok(Location {
+                    scheme,
+                    authority,
+                    path,
+                    raw,
+                })
+            }
+        }
+    }
+}
+
+fn parse_raw_location(value: String) -> Result<Location, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(Location {
+            scheme: "file".to_string(),
+            authority: None,
+            path: "/".to_string(),
+            raw: "file:///".to_string(),
+        });
+    }
+
+    if let Some(idx) = trimmed.find("://") {
+        let scheme = trimmed[..idx].to_ascii_lowercase();
+        let remainder = &trimmed[idx + 3..];
+
+        let (authority, path_part) = if remainder.starts_with('/') {
+            (None, remainder)
+        } else if let Some(slash_idx) = remainder.find('/') {
+            let (auth, path) = remainder.split_at(slash_idx);
+            (Some(auth.to_string()), path)
+        } else {
+            (Some(remainder.to_string()), "/")
+        };
+
+        let path = sanitize_path(path_part);
+        let raw = compose_raw_uri(&scheme, authority.as_deref(), &path);
+        Ok(Location {
+            scheme,
+            authority,
+            path,
+            raw,
+        })
+    } else {
+        let path = sanitize_path(trimmed);
+        let raw = compose_raw_uri("file", None, &path);
+        Ok(Location {
+            scheme: "file".to_string(),
+            authority: None,
+            path,
+            raw,
+        })
+    }
+}
+
+fn sanitize_path(input: impl Into<String>) -> String {
+    let mut value = input.into();
+    if value.is_empty() {
+        return "/".to_string();
+    }
+    if value.starts_with("//") {
+        // preserve leading double-slash for network paths
+        let segments: Vec<&str> = value.splitn(3, '/').collect();
+        if segments.len() >= 3 {
+            // segments[0] is empty, segments[1] is empty, segments[2] begins host
+            // we return //host/rest
+            if !segments[2].starts_with('/') {
+                return format!("//{}", segments[2]);
+            }
+        }
+    }
+    if !value.starts_with('/') {
+        value = format!("/{value}");
+    }
+    if value.len() > 1 && value.ends_with('/') {
+        value.pop();
+    }
+    value
+}
+
+pub struct ProviderDirectoryEntries {
+    pub location: LocationSummary,
+    pub entries: Vec<FileItem>,
+}
+
+pub trait LocationProvider: Send + Sync {
+    fn scheme(&self) -> &'static str;
+    fn capabilities(&self, location: &Location) -> LocationCapabilities;
+
+    fn read_directory(&self, location: &Location) -> Result<ProviderDirectoryEntries, String>;
+    fn get_file_metadata(&self, location: &Location) -> Result<FileItem, String>;
+    fn create_directory(&self, location: &Location) -> Result<(), String>;
+    fn delete(&self, location: &Location) -> Result<(), String>;
+    fn rename(&self, from: &Location, to: &Location) -> Result<(), String>;
+    fn copy(&self, from: &Location, to: &Location) -> Result<(), String>;
+    fn move_item(&self, from: &Location, to: &Location) -> Result<(), String> {
+        self.rename(from, to)
+    }
+}
+
+pub fn get_provider_for_scheme(scheme: &str) -> Option<ProviderRef> {
+    REGISTRY
+        .read()
+        .ok()
+        .and_then(|map| map.get(&scheme.to_ascii_lowercase()).cloned())
+}
+
+pub fn ensure_provider(scheme: &str) -> Result<ProviderRef, String> {
+    get_provider_for_scheme(scheme)
+        .ok_or_else(|| format!("No provider registered for scheme '{scheme}'"))
+}
+
+pub fn resolve_location(input: LocationInput) -> Result<(ProviderRef, Location), String> {
+    let location = input.into_location()?;
+    let provider = ensure_provider(location.scheme())?;
+    Ok((provider, location))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_file_paths() {
+        let raw = "/Users/example".to_string();
+        let loc = LocationInput::Raw(raw).into_location().unwrap();
+        assert_eq!(loc.scheme(), "file");
+        assert_eq!(loc.path(), "/Users/example");
+        assert_eq!(loc.raw(), "file:///Users/example");
+    }
+
+    #[test]
+    fn parse_uri_with_authority() {
+        let loc = LocationInput::Raw("s3://bucket/path".into())
+            .into_location()
+            .unwrap();
+        assert_eq!(loc.scheme(), "s3");
+        assert_eq!(loc.authority(), Some("bucket"));
+        assert_eq!(loc.path(), "/path");
+        assert_eq!(loc.raw(), "s3://bucket/path");
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import Toast from './components/Toast';
 import type {
   DirectoryChangeEventPayload,
+  DirectoryListingResponse,
   FileItem,
   PersistedPreferences,
   ViewPreferences,
@@ -262,11 +263,19 @@ function App() {
         // Now try to load the initial directory
         let loadSuccess = false;
         try {
-          const files = await invoke<FileItem[]>('read_directory', { path: startPath });
+          const listing = await invoke<DirectoryListingResponse>('read_directory', {
+            path: startPath,
+          });
+          const files = listing.entries;
           setFiles(files);
-          await applySmartViewDefaults(startPath, files);
-          setCurrentPath(startPath);
-          navigateTo(startPath);
+          useAppStore.setState({
+            currentLocationRaw: listing.location.raw,
+            currentProviderCapabilities: listing.capabilities,
+          });
+          await applySmartViewDefaults(listing.location.path, files);
+          const resolvedPath = listing.location.displayPath || listing.location.path;
+          setCurrentPath(resolvedPath);
+          navigateTo(resolvedPath);
           loadSuccess = true;
         } catch (dirError) {
           console.error('Failed to load initial directory:', startPath, dirError);
@@ -274,11 +283,19 @@ function App() {
           // Try fallback to home directory
           if (startPath !== homeDir) {
             try {
-              const files = await invoke<FileItem[]>('read_directory', { path: homeDir });
+              const listing = await invoke<DirectoryListingResponse>('read_directory', {
+                path: homeDir,
+              });
+              const files = listing.entries;
               setFiles(files);
-              await applySmartViewDefaults(homeDir, files);
-              setCurrentPath(homeDir);
-              navigateTo(homeDir);
+              useAppStore.setState({
+                currentLocationRaw: listing.location.raw,
+                currentProviderCapabilities: listing.capabilities,
+              });
+              await applySmartViewDefaults(listing.location.path, files);
+              const resolvedPath = listing.location.displayPath || listing.location.path;
+              setCurrentPath(resolvedPath);
+              navigateTo(resolvedPath);
               loadSuccess = true;
             } catch (homeError) {
               console.error('Failed to load home directory:', homeError);
@@ -289,11 +306,19 @@ function App() {
           if (!loadSuccess) {
             try {
               const rootPath = '/';
-              const files = await invoke<FileItem[]>('read_directory', { path: rootPath });
+              const listing = await invoke<DirectoryListingResponse>('read_directory', {
+                path: rootPath,
+              });
+              const files = listing.entries;
               setFiles(files);
-              await applySmartViewDefaults(rootPath, files);
-              setCurrentPath(rootPath);
-              navigateTo(rootPath);
+              useAppStore.setState({
+                currentLocationRaw: listing.location.raw,
+                currentProviderCapabilities: listing.capabilities,
+              });
+              await applySmartViewDefaults(listing.location.path, files);
+              const resolvedPath = listing.location.displayPath || listing.location.path;
+              setCurrentPath(resolvedPath);
+              navigateTo(resolvedPath);
               loadSuccess = true;
             } catch (rootError) {
               console.error('Failed to load root directory:', rootError);
@@ -389,9 +414,16 @@ function App() {
         }
 
         // Try to load the directory
-        const files = await invoke<FileItem[]>('read_directory', { path: currentPath });
+        const listing = await invoke<DirectoryListingResponse>('read_directory', {
+          path: currentPath,
+        });
+        const files = listing.entries;
         setFiles(files);
-        await applySmartViewDefaults(currentPath, files);
+        useAppStore.setState({
+          currentLocationRaw: listing.location.raw,
+          currentProviderCapabilities: listing.capabilities,
+        });
+        await applySmartViewDefaults(listing.location.path, files);
         setError(undefined); // Clear any previous errors on success
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -1036,8 +1068,14 @@ function App() {
           try {
             setLoading(true);
             setError(undefined);
-            const files = await invoke<FileItem[]>('read_directory', { path: currentPath });
-            setFiles(files);
+            const listing = await invoke<DirectoryListingResponse>('read_directory', {
+              path: currentPath,
+            });
+            setFiles(listing.entries);
+            useAppStore.setState({
+              currentLocationRaw: listing.location.raw,
+              currentProviderCapabilities: listing.capabilities,
+            });
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             const hint = msg.includes('Operation not permitted')

--- a/src/components/PathBar.tsx
+++ b/src/components/PathBar.tsx
@@ -20,7 +20,7 @@ import {
   X,
 } from 'phosphor-react';
 import { invoke } from '@tauri-apps/api/core';
-import type { DirectoryPreferencesMap, FileItem } from '@/types';
+import type { DirectoryPreferencesMap, DirectoryListingResponse, FileItem } from '@/types';
 import { useAppStore } from '@/store/useAppStore';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import ZoomSlider from './ZoomSlider';
@@ -118,9 +118,10 @@ const fetchSuggestionsForInfo = async ({
     entries = files;
   } else {
     const fetchPath = prefix.length === 0 ? sep : prefix;
-    entries = await invoke<FileItem[]>('read_directory', {
+    const response = await invoke<DirectoryListingResponse>('read_directory', {
       path: fetchPath || '/',
     });
+    entries = response.entries;
   }
 
   const partialLower = partialSegment.toLocaleLowerCase();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,34 @@ export interface FileItem {
   extension?: string;
 }
 
+export interface LocationSummary {
+  raw: string;
+  scheme: string;
+  authority?: string | null;
+  path: string;
+  displayPath: string;
+}
+
+export interface LocationCapabilities {
+  scheme: string;
+  displayName: string;
+  canRead: boolean;
+  canWrite: boolean;
+  canCreateDirectories: boolean;
+  canDelete: boolean;
+  canRename: boolean;
+  canCopy: boolean;
+  canMove: boolean;
+  supportsWatching: boolean;
+  requiresExplicitRefresh: boolean;
+}
+
+export interface DirectoryListingResponse {
+  location: LocationSummary;
+  capabilities: LocationCapabilities;
+  entries: FileItem[];
+}
+
 export interface ViewPreferences {
   viewMode: 'grid' | 'list' | 'details';
   sortBy: 'name' | 'size' | 'modified' | 'type';


### PR DESCRIPTION
## Summary
- introduce location provider registry and local filesystem provider
- update core commands and frontend store to consume provider-aware responses
- document the architecture for future s3/smb/ftp backends

## Testing
- npm run lint
- cd src-tauri && cargo check

Closes #67