### PR TITLE
feat: add badges to pinned items, folder counts, and macOS bundle support

### DIFF
--- a/src/__tests__/unit/store/useAppStore.test.ts
+++ b/src/__tests__/unit/store/useAppStore.test.ts
@@ -307,6 +307,8 @@ describe('useAppStore', () => {
       name: 'Test Directory',
       path: '/test/directory',
       pinned_at: '2024-01-01T00:00:00.000Z',
+      is_git_repo: false,
+      is_symlink: false,
     };
 
     describe('loadPinnedDirectories', () => {
@@ -405,6 +407,8 @@ describe('useAppStore', () => {
         name: 'Another Directory',
         path: '/another/directory',
         pinned_at: '2024-01-02T00:00:00.000Z',
+        is_git_repo: false,
+        is_symlink: false,
       };
 
       it('should reorder pinned directories', async () => {

--- a/src/components/FileNameDisplay.tsx
+++ b/src/components/FileNameDisplay.tsx
@@ -254,9 +254,13 @@ function FileNameDisplayInner({
               </div>
             </div>
           )}
-          {!file.is_directory && showSize && (
+          {showSize && (
             <div className={`text-xs mt-1 ${isSelected ? 'text-white/80' : 'text-app-muted'}`}>
-              {formatFileSize(file.size)}
+              {file.is_directory
+                ? file.child_count != null
+                  ? `${file.child_count} item${file.child_count !== 1 ? 's' : ''}`
+                  : null
+                : formatFileSize(file.size)}
             </div>
           )}
         </div>

--- a/src/components/FileTypeIcon.tsx
+++ b/src/components/FileTypeIcon.tsx
@@ -26,6 +26,9 @@ export function resolveVSCodeIcon(name: string, ext?: string): string | undefine
   if (filename === 'go.mod' || filename === 'go.sum') return 'vscode-icons:file-type-go';
   if (filename === '.env' || filename.startsWith('.env.')) return 'vscode-icons:file-type-dotenv';
 
+  // Windows system files - return undefined to use FileExtensionBadge (shows "INI", "DB" badge)
+  if (filename === 'desktop.ini' || filename === 'thumbs.db') return undefined;
+
   const map: Record<string, string> = {
     // Archives (use the standard VSCode zip icon for all)
     zip: 'vscode-icons:file-type-zip',
@@ -91,7 +94,6 @@ export function resolveVSCodeIcon(name: string, ext?: string): string | undefine
     yaml: 'vscode-icons:file-type-yaml',
     yml: 'vscode-icons:file-type-yaml',
     toml: 'vscode-icons:file-type-toml',
-    ini: 'vscode-icons:file-type-settings',
     xml: 'vscode-icons:file-type-xml',
     sql: 'vscode-icons:file-type-sql',
     env: 'vscode-icons:file-type-dotenv',

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,6 +15,8 @@ import {
   Folder,
   MusicNotes,
 } from 'phosphor-react';
+import GitRepoBadge from './GitRepoBadge';
+import SymlinkBadge from './SymlinkBadge';
 import type { IconProps } from 'phosphor-react';
 import { useAppStore } from '../store/useAppStore';
 import { useCallback, useEffect, useState, MouseEvent, useRef } from 'react';
@@ -392,7 +394,17 @@ export default function Sidebar() {
                           className="flex items-center gap-2 flex-1 min-w-0"
                           data-tauri-drag-region={false}
                         >
-                          {createIcon(Folder, 'fill', isActive)}
+                          <span className="relative flex-shrink-0 w-5 h-5">
+                            <div className="w-full h-full flex items-center justify-center">
+                              {createIcon(Folder, 'fill', isActive)}
+                            </div>
+                            {pin.is_git_repo && (
+                              <GitRepoBadge size="sm" style={{ bottom: -2, right: -2 }} />
+                            )}
+                            {pin.is_symlink && (
+                              <SymlinkBadge size="sm" style={{ bottom: -2, left: -2 }} />
+                            )}
+                          </span>
                           <span className={`truncate ${isActive ? 'text-accent' : ''}`}>
                             {pin.name}
                           </span>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ export interface FileItem {
   is_symlink: boolean; // Match Rust snake_case
   is_git_repo: boolean; // Match Rust snake_case
   extension?: string;
+  child_count?: number; // Shallow file count for directories
 }
 
 export interface LocationSummary {
@@ -89,6 +90,8 @@ export interface PinnedDirectory {
   name: string;
   path: string;
   pinned_at: string; // ISO 8601 string from Rust DateTime<Utc>
+  is_git_repo: boolean;
+  is_symlink: boolean;
 }
 
 export interface PersistedPreferences {

--- a/src/utils/fileTypes.ts
+++ b/src/utils/fileTypes.ts
@@ -100,3 +100,51 @@ export function getEffectiveExtension(
 
   return undefined;
 }
+
+/**
+ * macOS bundle extensions - directories that should be opened with system apps,
+ * not navigated into like regular folders. These are "packages" in macOS terminology.
+ */
+export const MACOS_BUNDLE_EXTENSIONS = new Set([
+  'app', // Applications
+  'photoslibrary', // Photos Library
+  'musiclibrary', // Music Library
+  'aplibrary', // Aperture Library
+  'fcpbundle', // Final Cut Pro bundle
+  'fcpproject', // Final Cut Pro project
+  'band', // GarageBand project
+  'scriv', // Scrivener project
+  'rtfd', // Rich Text with attachments
+  'playground', // Xcode playground
+  'xcodeproj', // Xcode project
+  'xcworkspace', // Xcode workspace
+  'framework', // macOS framework
+  'bundle', // Generic bundle
+  'plugin', // Plugin bundle
+  'kext', // Kernel extension
+  'prefpane', // System Preferences pane
+  'saver', // Screen saver
+  'slidesaver', // Screen saver (slides)
+  'qlgenerator', // QuickLook generator
+  'mdimporter', // Spotlight importer
+  'appex', // App extension
+]);
+
+/**
+ * Check if a file is a macOS bundle (directory that acts like a file)
+ */
+export function isMacOSBundle(file: Pick<FileItem, 'name' | 'is_directory'>): boolean {
+  if (!file.is_directory) return false;
+  const name = file.name.toLowerCase();
+  const dotIndex = name.lastIndexOf('.');
+  if (dotIndex === -1) return false;
+  const ext = name.slice(dotIndex + 1);
+  return MACOS_BUNDLE_EXTENSIONS.has(ext);
+}
+
+/**
+ * Check if a file is an app bundle specifically (for special icon handling)
+ */
+export function isAppBundle(file: Pick<FileItem, 'name' | 'is_directory'>): boolean {
+  return file.is_directory && file.name.toLowerCase().endsWith('.app');
+}


### PR DESCRIPTION
## Summary

- **Git/symlink badges on pinned sidebar items** (closes #51) - Pinned directories now show the same git repo and symlink badges as files in the main view
- **Folder item counts** - Directories now display shallow file counts (e.g., "12 items") in both grid and list views
- **macOS bundle handling** - Treats `.photoslibrary`, `.musiclibrary`, `.band`, `.xcodeproj`, and 20+ other macOS bundle types like `.app` files:
  - Double-click opens with system handler instead of navigating into
  - Sorted as files, not folders (when "folders first" is enabled)
  - Shows purple package icon to distinguish from regular folders
- **Icon fixes** - `desktop.ini` and `Thumbs.db` now show the file extension badge style ("INI", "DB")

## Test plan

- [ ] Pin a git repository and verify the git badge appears
- [ ] Pin a symlinked directory and verify the symlink badge appears
- [ ] Navigate to a directory with folders and verify item counts display
- [ ] Navigate to Pictures and verify `.photoslibrary` shows package icon and opens Photos.app on double-click
- [ ] Verify `desktop.ini` and `Thumbs.db` show extension badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)