### PR TITLE
fix: resolve GitHub Actions caching issues

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,26 +74,19 @@ jobs:
         with:
           workspaces: |
             src-tauri -> target
+          shared-key: release-x86_64-unknown-linux-gnu
+          cache-all-crates: true
           cache-on-failure: true
 
       - name: Setup sccache
         if: steps.changes.outputs.check == 'true'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure compiler caching
         if: steps.changes.outputs.check == 'true'
         run: |
-          echo "SCCACHE_CACHE_SIZE=1G" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "SCCACHE_IGNORE_SERVER_IO_FAILURES=1" >> "$GITHUB_ENV"
-          echo "SCCACHE_DIR=$RUNNER_TEMP/sccache" >> "$GITHUB_ENV"
-          if sccache --start-server >/dev/null 2>&1; then
-            echo "Using sccache for rustc wrapper"
-            echo "RUSTC_WRAPPER=$(command -v sccache)" >> "$GITHUB_ENV"
-          else
-            echo "Sccache unavailable; falling back to rustc"
-            echo "RUSTC_WRAPPER=$(command -v rustc)" >> "$GITHUB_ENV"
-          fi
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         if: steps.changes.outputs.check == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,21 +266,12 @@ jobs:
             tauri-${{ runner.os }}-
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure compiler caching
         run: |
-          echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "SCCACHE_IGNORE_SERVER_IO_FAILURES=1" >> "$GITHUB_ENV"
-          echo "SCCACHE_DIR=$RUNNER_TEMP/sccache" >> "$GITHUB_ENV"
-          if sccache --start-server >/dev/null 2>&1; then
-            echo "Using sccache for rustc wrapper"
-            echo "RUSTC_WRAPPER=$(command -v sccache)" >> "$GITHUB_ENV"
-          else
-            echo "Sccache unavailable; falling back to rustc"
-            echo "RUSTC_WRAPPER=$(command -v rustc)" >> "$GITHUB_ENV"
-          fi
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Install frontend dependencies
         run: npm ci
@@ -423,21 +414,12 @@ jobs:
             tauri-${{ runner.os }}-
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure compiler caching
         run: |
-          echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "SCCACHE_IGNORE_SERVER_IO_FAILURES=1" >> "$GITHUB_ENV"
-          echo "SCCACHE_DIR=$RUNNER_TEMP/sccache" >> "$GITHUB_ENV"
-          if sccache --start-server >/dev/null 2>&1; then
-            echo "Using sccache for rustc wrapper"
-            echo "RUSTC_WRAPPER=$(command -v sccache)" >> "$GITHUB_ENV"
-          else
-            echo "Sccache unavailable; falling back to rustc"
-            echo "RUSTC_WRAPPER=$(command -v rustc)" >> "$GITHUB_ENV"
-          fi
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Install frontend dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Remove `SCCACHE_DIR` which conflicted with GHA cache mode (was storing in temp dir that gets deleted after each run)
- Update sccache-action from v0.0.9 to v0.0.10 (fixes GHA caching bugs)
- Simplify sccache config - action handles setup, just enable GHA mode
- Add shared-key to check.yml so it shares rust-cache with release builds

## Root Cause
The previous config set `SCCACHE_DIR=$RUNNER_TEMP/sccache` which told sccache to store its cache in a temporary directory. Even with `SCCACHE_GHA_ENABLED=true`, this local directory took precedence, causing 0% cache hit rate.

## Test plan
- [ ] Merge and observe the dry-run build
- [ ] Check sccache stats in build logs for cache hits
- [ ] Subsequent PRs should show improved cache hit rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)