### PR TITLE
feat: Improve macOS permissions and add code signing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS Apple Silicon (M1/M2/M3)
           - os: macos-14
-            target: universal-apple-darwin
-            arch: universal
-            rust-targets: x86_64-apple-darwin,aarch64-apple-darwin
+            target: aarch64-apple-darwin
+            arch: arm64
+            rust-targets: aarch64-apple-darwin
+          # macOS Intel
+          - os: macos-13
+            target: x86_64-apple-darwin
+            arch: x86_64
+            rust-targets: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             arch: x86_64
@@ -267,6 +273,32 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Import Apple Certificate
+        if: runner.os == 'macOS' && env.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          # Create temporary keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          # Create keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          echo "$APPLE_CERTIFICATE" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          security import $RUNNER_TEMP/certificate.p12 -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+          # Allow codesign to access keychain
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Clean up certificate file
+          rm -f $RUNNER_TEMP/certificate.p12
+
       - name: Build and publish installers
         uses: tauri-apps/tauri-action@v0
         env:
@@ -278,11 +310,18 @@ jobs:
           TAURI_LOG: trace
           RUST_LOG: tauri_bundler=debug
           TAURI_BUNDLE_LINUX_APPIMAGE_ARGS: ${{ runner.os == 'Linux' && '--verbosity=2' || '' }}
+          # Apple code signing (only if secrets are configured)
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: Marlin ${{ env.RELEASE_TAG }}
           releaseBody: |
             Automated binaries for Marlin. Download the installer matching your platform.
+
+            **macOS users**: Choose `arm64` for Apple Silicon (M1/M2/M3) or `x86_64` for Intel Macs.
           releaseDraft: false
           prerelease: ${{ startsWith(env.RELEASE_TAG, 'v0.') }}
           args: --target ${{ matrix.target }} --verbose
@@ -295,10 +334,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS Apple Silicon (M1/M2/M3)
           - os: macos-14
-            target: universal-apple-darwin
-            arch: universal
-            rust-targets: x86_64-apple-darwin,aarch64-apple-darwin
+            target: aarch64-apple-darwin
+            arch: arm64
+            rust-targets: aarch64-apple-darwin
+          # macOS Intel
+          - os: macos-13
+            target: x86_64-apple-darwin
+            arch: x86_64
+            rust-targets: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             arch: x86_64

--- a/docs/APPLE_SIGNING_GUIDE.md
+++ b/docs/APPLE_SIGNING_GUIDE.md
@@ -1,0 +1,182 @@
+# Apple Developer Code Signing Guide for Marlin
+
+This guide walks you through setting up Apple code signing and notarization for Marlin releases.
+
+## Why Sign Your App?
+
+- **No "unidentified developer" warnings** - Users can open the app without going to Security preferences
+- **Gatekeeper approval** - macOS trusts your app
+- **Persistent permissions** - File access permissions won't reset between updates
+- **Professional distribution** - Required for serious macOS apps
+
+## Cost
+
+Apple Developer Program membership costs **$99/year** (as of 2024).
+
+---
+
+## Step 1: Enroll in Apple Developer Program
+
+1. Go to [developer.apple.com/programs/enroll](https://developer.apple.com/programs/enroll/)
+2. Sign in with your Apple ID (or create one)
+3. Choose enrollment type:
+   - **Individual** - For personal projects (uses your real name)
+   - **Organization** - For companies (requires D-U-N-S number)
+4. Pay the $99 annual fee
+5. Wait for approval (usually instant for individuals, 24-48 hours for organizations)
+
+---
+
+## Step 2: Create a Developer ID Certificate
+
+Once enrolled, create a certificate for signing apps distributed outside the App Store:
+
+### Option A: Using Xcode (Recommended)
+
+1. Open **Xcode** → **Settings** (⌘,) → **Accounts**
+2. Select your Apple ID → Click **Manage Certificates**
+3. Click **+** → **Developer ID Application**
+4. Xcode creates and installs the certificate automatically
+
+### Option B: Using Apple Developer Portal
+
+1. Go to [developer.apple.com/account/resources/certificates](https://developer.apple.com/account/resources/certificates/list)
+2. Click **+** to create a new certificate
+3. Select **Developer ID Application**
+4. Follow the CSR (Certificate Signing Request) instructions:
+   - Open **Keychain Access** → **Certificate Assistant** → **Request a Certificate from a Certificate Authority**
+   - Enter your email, leave CA Email blank, select "Saved to disk"
+5. Upload the CSR and download the certificate
+6. Double-click the `.cer` file to install it in Keychain
+
+---
+
+## Step 3: Export Certificate as .p12
+
+For GitHub Actions, you need to export your certificate:
+
+1. Open **Keychain Access**
+2. Go to **My Certificates** (in the sidebar under Category)
+3. Find **Developer ID Application: Your Name (TEAM_ID)**
+4. Right-click → **Export**
+5. Save as `.p12` format
+6. Set a strong password (you'll need this later)
+
+---
+
+## Step 4: Create App-Specific Password
+
+For notarization, Apple requires an app-specific password:
+
+1. Go to [appleid.apple.com](https://appleid.apple.com/)
+2. Sign in → **App-Specific Passwords**
+3. Click **+** to generate a new password
+4. Name it something like "Marlin Notarization"
+5. Copy the generated password (format: `xxxx-xxxx-xxxx-xxxx`)
+
+---
+
+## Step 5: Find Your Team ID
+
+1. Go to [developer.apple.com/account](https://developer.apple.com/account)
+2. Scroll down to **Membership Details**
+3. Copy your **Team ID** (10-character alphanumeric)
+
+---
+
+## Step 6: Configure GitHub Secrets
+
+Go to your repository → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**
+
+Add these secrets:
+
+| Secret Name                  | Value                                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------ |
+| `APPLE_CERTIFICATE`          | Base64-encoded .p12 file (see below)                                                       |
+| `APPLE_CERTIFICATE_PASSWORD` | Password you set when exporting .p12                                                       |
+| `APPLE_SIGNING_IDENTITY`     | Your certificate's Common Name, e.g. `Developer ID Application: Example Corp (A1B2C3D4E5)` |
+| `APPLE_ID`                   | Your Apple ID email                                                                        |
+| `APPLE_PASSWORD`             | App-specific password from Step 4                                                          |
+| `APPLE_TEAM_ID`              | Your 10-character Team ID                                                                  |
+
+### Encoding the Certificate
+
+Run this command to base64-encode your .p12 file:
+
+```bash
+base64 -i path/to/certificate.p12 | pbcopy
+```
+
+This copies the encoded certificate to your clipboard. Paste it as the `APPLE_CERTIFICATE` secret.
+
+---
+
+## Step 7: Verify Your Setup
+
+After adding all secrets, trigger a release build. Check the logs for:
+
+- ✅ "Import Apple Certificate" step succeeds
+- ✅ "codesign" commands execute without errors
+- ✅ "notarytool" successfully submits for notarization
+- ✅ Notarization completes with "Accepted"
+
+---
+
+## Troubleshooting
+
+### "The specified item could not be found in the keychain"
+
+- Ensure the certificate was imported correctly
+- Check that `APPLE_CERTIFICATE_PASSWORD` matches exactly
+
+### "Developer ID Application certificate not found"
+
+- Verify `APPLE_SIGNING_IDENTITY` matches the certificate name exactly
+- Format: `Developer ID Application: Your Name (TEAM_ID)`
+
+### Notarization fails with "Invalid credentials"
+
+- Regenerate the app-specific password
+- Ensure `APPLE_ID` and `APPLE_PASSWORD` are correct
+- Check that your Apple Developer membership is active
+
+### "Code signature invalid"
+
+- Make sure entitlements file exists at `src-tauri/Entitlements.plist`
+- Verify the entitlements are valid for your app's capabilities
+
+---
+
+## Local Development Signing
+
+For local builds, you can sign with your certificate:
+
+```bash
+# Build with signing (uses certificate from Keychain)
+npm run tauri build
+
+# The bundler will automatically use your Developer ID certificate
+# if it's installed in your Keychain
+```
+
+---
+
+## Summary Checklist
+
+- [ ] Enrolled in Apple Developer Program ($99/year)
+- [ ] Created Developer ID Application certificate
+- [ ] Exported certificate as .p12
+- [ ] Created app-specific password for notarization
+- [ ] Found Team ID
+- [ ] Added all 6 secrets to GitHub repository
+- [ ] Triggered a test release to verify
+
+Once configured, every release will be automatically signed and notarized!
+
+---
+
+## References
+
+- [Apple Developer Program](https://developer.apple.com/programs/)
+- [Tauri macOS Code Signing](https://v2.tauri.app/distribute/sign/macos/)
+- [Apple Notarization Guide](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "phosphor-react": "^1.4.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "tauri-plugin-macos-permissions-api": "^2.3.0",
         "zustand": "^5.0.8"
       },
       "bin": {
@@ -6954,6 +6955,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tauri-plugin-macos-permissions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tauri-plugin-macos-permissions-api/-/tauri-plugin-macos-permissions-api-2.3.0.tgz",
+      "integrity": "sha512-pZp0jmDySysBqrGueknd1a7Rr4XEO9aXpMv9TNrT2PDHP0MSH20njieOagsFYJ5MCVb8A+wcaK0cIkjUC2dOww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tauri-apps/api": "^2.5.0"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@tauri-apps/plugin-opener": "^2.0.0",
     "@tauri-apps/plugin-os": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",
+    "tauri-plugin-macos-permissions-api": "^2.3.0",
     "clsx": "^2.1.1",
     "phosphor-react": "^1.4.1",
     "react": "^19.1.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,11 +70,11 @@ zstd = "0.13"
 async-trait = "0.1"
 trash = "5.2.5"
 
-
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = { version = "0.25" }
 objc = { version = "0.2" }
 block = "0.1"
+tauri-plugin-macos-permissions = "2.3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = ["Win32_Storage_FileSystem"] }

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        Required by WebKit's JavaScript JIT compiler.
+        Tauri uses WebKit (WKWebView) for rendering the app's webview,
+        and the JIT requires executable memory for performance.
+    -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,6 +75,17 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_decorum::init())
         .plugin(tauri_plugin_drag::init())
+        .plugin({
+            #[cfg(target_os = "macos")]
+            {
+                tauri_plugin_macos_permissions::init()
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                // No-op plugin for non-macOS platforms
+                tauri::plugin::Builder::<_, ()>::new("macos-permissions-noop").build()
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             commands::get_home_directory,
             commands::get_disk_usage,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,10 @@
       "icons/256x256.png",
       "icons/128x128.png",
       "icons/32x32.png"
-    ]
+    ],
+    "macOS": {
+      "entitlements": "./Entitlements.plist",
+      "signingIdentity": null
+    }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { message } from '@tauri-apps/plugin-dialog';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 
 import Toast from './components/Toast';
+import PermissionPrompt from './components/PermissionPrompt';
 import type {
   DirectoryChangeEventPayload,
   DirectoryListingResponse,
@@ -1302,6 +1303,9 @@ function App() {
 
       {/* Toast notifications */}
       <Toast />
+
+      {/* macOS Full Disk Access permission prompt */}
+      <PermissionPrompt />
     </div>
   );
 }

--- a/src/components/PermissionPrompt.tsx
+++ b/src/components/PermissionPrompt.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { platform } from '@tauri-apps/plugin-os';
+import { ShieldCheck, FolderSimple, X } from 'phosphor-react';
+
+// Storage key for dismissal state
+const PERMISSION_DISMISSED_KEY = 'marlin_fda_prompt_dismissed';
+
+// Type definitions for the macos-permissions plugin
+interface MacOSPermissionsAPI {
+  checkFullDiskAccessPermission: () => Promise<boolean>;
+  requestFullDiskAccessPermission: () => Promise<void>;
+}
+
+interface PermissionPromptProps {
+  onClose?: () => void;
+}
+
+export default function PermissionPrompt({ onClose }: PermissionPromptProps) {
+  const [visible, setVisible] = useState(false);
+  const [checking, setChecking] = useState(true);
+
+  // Use ref to store the dynamically loaded API to avoid module-level mutable state
+  const permissionsAPIRef = useRef<MacOSPermissionsAPI | null>(null);
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      // Only show on macOS
+      const currentPlatform = platform();
+      if (currentPlatform !== 'macos') {
+        setChecking(false);
+        return;
+      }
+
+      // Check if user previously dismissed
+      const dismissed = localStorage.getItem(PERMISSION_DISMISSED_KEY);
+      if (dismissed === 'true') {
+        setChecking(false);
+        return;
+      }
+
+      // Dynamically import the macos-permissions plugin (only available on macOS)
+      try {
+        const mod = await import('tauri-plugin-macos-permissions-api');
+        permissionsAPIRef.current = {
+          checkFullDiskAccessPermission:
+            mod.checkFullDiskAccessPermission as () => Promise<boolean>,
+          requestFullDiskAccessPermission:
+            mod.requestFullDiskAccessPermission as () => Promise<void>,
+        };
+      } catch {
+        // Plugin not available
+        setChecking(false);
+        return;
+      }
+
+      // Check if FDA is already granted
+      try {
+        const hasAccess = await permissionsAPIRef.current.checkFullDiskAccessPermission();
+        if (!hasAccess) {
+          setVisible(true);
+        }
+      } catch (error) {
+        console.warn('Failed to check Full Disk Access permission:', error);
+      }
+
+      setChecking(false);
+    };
+
+    checkPermission();
+  }, []);
+
+  const handleGrantAccess = useCallback(async () => {
+    if (!permissionsAPIRef.current) return;
+
+    try {
+      await permissionsAPIRef.current.requestFullDiskAccessPermission();
+      // The system preferences will open - close the prompt
+      setVisible(false);
+      onClose?.();
+    } catch (error) {
+      console.error('Failed to request Full Disk Access:', error);
+    }
+  }, [onClose]);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+    onClose?.();
+  }, [onClose]);
+
+  const handleDontAskAgain = useCallback(() => {
+    localStorage.setItem(PERMISSION_DISMISSED_KEY, 'true');
+    setVisible(false);
+    onClose?.();
+  }, [onClose]);
+
+  if (checking || !visible) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="relative bg-app-surface rounded-xl shadow-2xl max-w-md w-full mx-4 overflow-hidden border border-app-border">
+        {/* Close button */}
+        <button
+          onClick={handleDismiss}
+          className="absolute top-3 right-3 p-1.5 rounded-lg hover:bg-app-hover text-app-muted hover:text-app-text transition-colors"
+          aria-label="Close"
+        >
+          <X size={18} weight="bold" />
+        </button>
+
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 text-center">
+          <div className="mx-auto w-16 h-16 rounded-full bg-app-accent/10 flex items-center justify-center mb-4">
+            <ShieldCheck size={32} weight="duotone" className="text-app-accent" />
+          </div>
+          <h2 className="text-lg font-semibold text-app-text mb-2">Full Disk Access Recommended</h2>
+          <p className="text-sm text-app-muted leading-relaxed">
+            For the best experience, grant Marlin Full Disk Access. This eliminates permission
+            prompts when browsing protected folders.
+          </p>
+        </div>
+
+        {/* Benefits */}
+        <div className="px-6 pb-4">
+          <div className="bg-app-dark/50 rounded-lg p-4 space-y-3">
+            <div className="flex items-start gap-3">
+              <FolderSimple size={20} className="text-app-accent mt-0.5 shrink-0" />
+              <div className="text-sm">
+                <span className="text-app-text font-medium">
+                  Access Downloads, Documents & more
+                </span>
+                <p className="text-app-muted text-xs mt-0.5">
+                  Browse all your folders without repeated prompts
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <ShieldCheck size={20} className="text-app-accent mt-0.5 shrink-0" />
+              <div className="text-sm">
+                <span className="text-app-text font-medium">Your choice, your control</span>
+                <p className="text-app-muted text-xs mt-0.5">
+                  Revoke access anytime in System Settings
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="px-6 pb-6 space-y-2">
+          <button
+            onClick={handleGrantAccess}
+            className="w-full py-2.5 px-4 bg-app-accent hover:bg-app-accent/90 text-white rounded-lg font-medium transition-colors"
+          >
+            Open System Settings
+          </button>
+          <div className="flex justify-center gap-4 pt-1">
+            <button
+              onClick={handleDismiss}
+              className="text-sm text-app-muted hover:text-app-text transition-colors"
+            >
+              Not now
+            </button>
+            <button
+              onClick={handleDontAskAgain}
+              className="text-sm text-app-muted hover:text-app-text transition-colors"
+            >
+              Don&apos;t ask again
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add Full Disk Access permission prompt on first launch for macOS users
- Split Universal builds into separate arm64 and x86_64 releases (fixes repeated permission prompts bug)
- Add Apple code signing and notarization support to release workflow
- Add comprehensive Apple Developer signing guide

## Changes

### Permission Prompt
New `PermissionPrompt` component that:
- Checks for Full Disk Access on macOS startup
- Shows a friendly modal explaining benefits if FDA isn't granted
- Offers "Open System Settings" to grant FDA
- Has "Not now" and "Don't ask again" options
- Remembers dismissal preference in localStorage

### Separate Architecture Builds
Changed from Universal (`universal-apple-darwin`) to separate builds:
- `aarch64-apple-darwin` on macos-14 (Apple Silicon)
- `x86_64-apple-darwin` on macos-13 (Intel)

This avoids the [known Tauri bug](https://github.com/tauri-apps/tauri/issues/8041) where Universal apps prompt repeatedly for permissions.

### Code Signing Support
Added certificate import and signing environment variables to the release workflow. To enable:
1. Follow `docs/APPLE_SIGNING_GUIDE.md`
2. Add the 6 required secrets to your repo

Without secrets configured, releases build normally (unsigned but with separate architectures).

## Test plan

- [ ] Verify frontend builds: `npm run build`
- [ ] Verify backend builds: `cd src-tauri && cargo build`
- [ ] Test permission prompt appears on macOS (release build only)
- [ ] Test "Don't ask again" persists across restarts
- [ ] Verify GitHub Actions workflow runs correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)