### PR TITLE
refactor: Simplify codebase with cascading deletions

### DIFF
--- a/src/components/AppIcon.tsx
+++ b/src/components/AppIcon.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { useThumbnail } from '@/hooks/useThumbnail';
+import { usePlatform } from '@/hooks/usePlatform';
 
 interface AppIconProps {
   path: string;
@@ -29,8 +30,7 @@ export default function AppIcon({
     format: 'png', // Use PNG for app icons to preserve transparency
   });
 
-  const isMac =
-    typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC');
+  const { isMac } = usePlatform();
   const shouldShowThumbnail =
     isMac && (path.toLowerCase().endsWith('.app') || path.toLowerCase().endsWith('.pkg'));
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,6 +25,7 @@ import { SystemDrive, PinnedDirectory } from '../types';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { useToastStore } from '../store/useToastStore';
 import { useSidebarDropZone } from '../hooks/useDragDetector';
+import { usePlatform } from '@/hooks/usePlatform';
 import QuickTooltip from './QuickTooltip';
 
 type SidebarLink = {
@@ -243,6 +244,9 @@ export default function Sidebar() {
     }
   };
 
+  // Platform detection for special folders - must be before early return
+  const { isMac, isWindows } = usePlatform();
+
   if (!showSidebar) return null;
   // Safe join that returns null until base (home) is known
   const join = (base?: string, sub?: string): string | null => {
@@ -264,12 +268,6 @@ export default function Sidebar() {
     weight: 'fill' | 'regular' = 'fill',
     isActive: boolean
   ) => <IconComponent className={`w-5 h-5 ${isActive ? 'text-accent' : ''}`} weight={weight} />;
-
-  // Platform detection for special folders
-  const isMac =
-    typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC');
-  const isWindows =
-    typeof navigator !== 'undefined' && navigator.userAgent.toUpperCase().includes('WINDOWS');
   const trashPath = isMac
     ? join(home, '.Trash')
     : isWindows

--- a/src/hooks/useFileIcon.tsx
+++ b/src/hooks/useFileIcon.tsx
@@ -1,0 +1,156 @@
+import { useCallback } from 'react';
+import {
+  Folder,
+  ImageSquare,
+  MusicNote,
+  VideoCamera,
+  FileText,
+  AppWindow,
+  Package,
+  FilePdf,
+  PaintBrush,
+  Palette,
+  Disc,
+  Cube,
+} from 'phosphor-react';
+import { FileItem } from '../types';
+import AppIcon from '@/components/AppIcon';
+import { FileTypeIcon, resolveVSCodeIcon } from '@/components/FileTypeIcon';
+import FileExtensionBadge from '@/components/FileExtensionBadge';
+import {
+  getEffectiveExtension,
+  isArchiveExtension,
+  isVideoExtension,
+  isMacOSBundle,
+  isAppBundle,
+} from '@/utils/fileTypes';
+
+export type IconSize = 'small' | 'large';
+
+interface SizeConfig {
+  iconClass: string;
+  appIconClass: string;
+  appIconSize: number;
+  fileTypeSize: 'small' | 'large';
+}
+
+const SIZE_CONFIG: Record<IconSize, SizeConfig> = {
+  small: {
+    iconClass: 'w-5 h-5',
+    appIconClass: 'w-5 h-5',
+    appIconSize: 64,
+    fileTypeSize: 'small',
+  },
+  large: {
+    iconClass: 'w-12 h-12',
+    appIconClass: 'w-16 h-16',
+    appIconSize: 64,
+    fileTypeSize: 'large',
+  },
+};
+
+export function useFileIcon(size: IconSize, isMac: boolean) {
+  const config = SIZE_CONFIG[size];
+
+  const getFileIcon = useCallback(
+    (file: FileItem) => {
+      // macOS-specific file types
+      if (isMac) {
+        const fileName = file.name.toLowerCase();
+        if (file.is_directory && fileName.endsWith('.app')) {
+          return (
+            <AppIcon
+              path={file.path}
+              size={config.appIconSize}
+              className={config.appIconClass}
+              rounded={size === 'large'}
+              priority="high"
+              fallback={<AppWindow className={`${config.iconClass} text-accent`} />}
+            />
+          );
+        }
+
+        if (fileName.endsWith('.pkg')) {
+          return <Package className={`${config.iconClass} text-blue-500`} weight="fill" />;
+        }
+
+        if (fileName.endsWith('.dmg')) {
+          return <Disc className={`${config.iconClass} text-app-muted`} weight="fill" />;
+        }
+
+        if (isMacOSBundle(file) && !isAppBundle(file)) {
+          return <Package className={`${config.iconClass} text-purple-400`} weight="fill" />;
+        }
+      }
+
+      // Directories
+      if (file.is_directory) {
+        return <Folder className={`${config.iconClass} text-accent`} weight="fill" />;
+      }
+
+      const effectiveExtension = getEffectiveExtension(file);
+      const ext = effectiveExtension?.toLowerCase();
+
+      if (!ext) {
+        const special = resolveVSCodeIcon(file.name);
+        if (special) return <FileTypeIcon name={file.name} size={config.fileTypeSize} />;
+        return <FileExtensionBadge extension={effectiveExtension} size={config.fileTypeSize} />;
+      }
+
+      // Image files
+      if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp'].includes(ext)) {
+        return <ImageSquare className={`${config.iconClass} text-app-green`} />;
+      }
+
+      // PDF files
+      if (ext === 'pdf') {
+        return <FilePdf className={`${config.iconClass} text-red-500`} />;
+      }
+
+      // Adobe Illustrator files
+      if (ext === 'ai' || ext === 'eps') {
+        return <PaintBrush className={`${config.iconClass} text-orange-500`} />;
+      }
+
+      // Photoshop files
+      if (ext === 'psd' || ext === 'psb') {
+        return <Palette className={`${config.iconClass} text-blue-500`} />;
+      }
+
+      // Audio files
+      if (['mp3', 'wav', 'flac', 'aac', 'm4a', 'ogg'].includes(ext)) {
+        return <MusicNote className={`${config.iconClass} text-app-yellow`} />;
+      }
+
+      // Video files
+      if (isVideoExtension(ext)) {
+        return <VideoCamera className={`${config.iconClass} text-app-red`} />;
+      }
+
+      // Archive files
+      if (isArchiveExtension(ext)) {
+        return <FileTypeIcon name={file.name} ext={ext} size={config.fileTypeSize} />;
+      }
+
+      // 3D model: STL
+      if (ext === 'stl') {
+        return <Cube className={`${config.iconClass} text-app-green`} />;
+      }
+
+      // VSCode-style file icons for code/config types
+      if (resolveVSCodeIcon(file.name, ext)) {
+        return <FileTypeIcon name={file.name} ext={ext} size={config.fileTypeSize} />;
+      }
+
+      // Text files
+      if (['txt', 'md', 'json', 'xml', 'yml', 'yaml', 'toml'].includes(ext)) {
+        return <FileText className={`${config.iconClass} text-app-text`} />;
+      }
+
+      return <FileExtensionBadge extension={effectiveExtension} size={config.fileTypeSize} />;
+    },
+    [isMac, config, size]
+  );
+
+  return getFileIcon;
+}

--- a/src/hooks/usePlatform.ts
+++ b/src/hooks/usePlatform.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+interface PlatformInfo {
+  isMac: boolean;
+  isWindows: boolean;
+  isLinux: boolean;
+}
+
+function detectPlatform(): PlatformInfo {
+  if (typeof navigator === 'undefined') {
+    return { isMac: false, isWindows: false, isLinux: false };
+  }
+
+  const ua = navigator.userAgent.toLowerCase();
+  const platform = navigator.platform?.toLowerCase() ?? '';
+
+  // Use both userAgent and platform for reliability
+  const isMac = ua.includes('mac') || platform.includes('mac');
+  const isWindows = ua.includes('win') || platform.includes('win');
+  const isLinux = ua.includes('linux') || platform.includes('linux');
+
+  return { isMac, isWindows, isLinux };
+}
+
+// Cached result for non-hook contexts
+let cachedPlatform: PlatformInfo | null = null;
+
+export function getPlatform(): PlatformInfo {
+  if (!cachedPlatform) {
+    cachedPlatform = detectPlatform();
+  }
+  return cachedPlatform;
+}
+
+export function usePlatform(): PlatformInfo {
+  return useMemo(() => getPlatform(), []);
+}


### PR DESCRIPTION
## Summary

Apply systematic code simplification following the "cascading deletions" pattern - finding small structural changes that unlock large amounts of code removal.

### Rust Backend
- Delete duplicate `build_file_item_fast` function (identical to `build_file_item`)
- Create generic `WindowPayloadQueue<T>` to replace 6 duplicate statics and 6 duplicate functions for window payload handling

### TypeScript Frontend
- Create `useFileIcon` hook to consolidate duplicate icon logic from FileGrid.tsx and FileList.tsx
- Create `usePlatform` hook to provide consistent platform detection, replacing 3 different inline detection patterns

## Impact
- **489 lines deleted, 289 lines added (net -200 lines)**
- Eliminated maintenance burden of keeping duplicate code in sync
- Improved consistency across platform detection
- Better separation of concerns with reusable hooks

## Test plan
- [x] `npm run build` passes
- [x] `cargo build` passes with no warnings
- [x] Linting passes
- [x] TypeScript type checking passes
- [ ] CI builds pass
- [ ] Manual testing of file grid/list views
- [ ] Manual testing of app icon loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)