### PR TITLE
fix: Use ad-hoc signing when Apple secrets unavailable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,8 +310,8 @@ jobs:
           TAURI_LOG: trace
           RUST_LOG: tauri_bundler=debug
           TAURI_BUNDLE_LINUX_APPIMAGE_ARGS: ${{ runner.os == 'Linux' && '--verbosity=2' || '' }}
-          # Apple code signing (only if secrets are configured)
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # Apple code signing (use ad-hoc signing with '-' if secrets not configured)
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
## Summary
- Falls back to ad-hoc signing (`-`) when `APPLE_SIGNING_IDENTITY` secret is not configured
- Fixes the "item not found in keychain" error that was failing macOS release builds

## Details
When the Apple Developer certificate secrets are not configured, the workflow was passing an empty string to `APPLE_SIGNING_IDENTITY`, causing Tauri to attempt signing with an empty identity which fails.

This change makes macOS builds succeed by using ad-hoc signing as a fallback. Users will need to right-click → Open to bypass Gatekeeper, but binaries will be functional.

Once Apple Developer ID certificates are available, simply add the `APPLE_SIGNING_IDENTITY` secret and builds will use proper signing automatically.

## Test plan
- [ ] PR dry-run workflow should pass for all platforms
- [ ] After merge, re-run release for v0.1.5 (or create v0.1.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)