### PR TITLE
fix(ci): use SMG_TOKEN for release version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ steps.context.outputs.default_branch }}
+          token: ${{ secrets.SMG_TOKEN }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Fix release workflow failing due to branch protection rules
- Use org-level `SMG_TOKEN` instead of default `GITHUB_TOKEN` for version sync commits
- Allows the sync-version job to push directly to master during releases

## Changes

### CI/CD
- `.github/workflows/release.yml` - Added `token: ${{ secrets.SMG_TOKEN }}` to checkout step in sync-version job

## Context

The release workflow failed with:
```
remote: error: GH013: Repository rule violations found for refs/heads/master.
remote: - Changes must be made through the merge queue
remote: - Changes must be made through a pull request.
```

The `smg-actions` app is already configured with bypass permissions in the repo ruleset. Using `SMG_TOKEN` allows the workflow to push version sync commits during releases.

Failed run: https://github.com/StirlingMarketingGroup/marlin/actions/runs/20938178442

## Test Plan
- [ ] Merge this PR
- [ ] Trigger a new release and verify the sync-version job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)