### PR TITLE
fix(ci): use GitHub App token for release version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,13 @@ jobs:
       default_branch: ${{ steps.context.outputs.default_branch }}
       changes_detected: ${{ steps.diff.outputs.changed }}
     steps:
+      - name: Generate GitHub App token
+        id: smg-actions
+        uses: getsentry/action-github-app-token@v3
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Resolve release context
         id: context
         shell: bash
@@ -71,7 +78,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ steps.context.outputs.default_branch }}
-          token: ${{ secrets.SMG_TOKEN }}
+          token: ${{ steps.smg-actions.outputs.token }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Uses `smg-actions` GitHub App token instead of `SMG_TOKEN` PAT for the release version sync job
- The app is on the ruleset bypass list with "Always allow" permission, allowing direct pushes to master
- Matches the pattern used in other org repos (e.g., `dependabot-lockfile-fix.yml`)

## Test plan
- [ ] Trigger a release (tag push or workflow dispatch) and verify the version sync commits successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)