### PR TITLE
fix: SMB thumbnails stuck on cache misses

### DIFF
--- a/src-tauri/src/thumbnails/worker.rs
+++ b/src-tauri/src/thumbnails/worker.rs
@@ -180,8 +180,18 @@ impl ThumbnailWorker {
                                     image_height: gen_result.image_height,
                                 })
                             }
-                            Ok(Err(e)) => Err(format!("Thumbnail generation failed: {}", e)),
-                            Err(e) => Err(format!("Task execution failed: {}", e)),
+                            Ok(Err(e)) => {
+                                log::warn!("THUMBNAIL GENERATION FAILED: path={}, error={}", request.path, e);
+                                Err(format!("Thumbnail generation failed: {}", e))
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "THUMBNAIL TASK FAILED: path={}, error={}",
+                                    request.path,
+                                    e
+                                );
+                                Err(format!("Task execution failed: {}", e))
+                            }
                         };
 
                         // Send response back


### PR DESCRIPTION
## Problem
SMB thumbnails would continuously log `THUMBNAIL CACHE MISS` and never resolve for some SMB paths.

## Fix
- Parse `smb://` paths leniently (don't use strict URL parsing) so hostnames and paths with non-URL characters work.
- Log backend thumbnail generation failures to make future issues visible.