### PR TITLE
fix: add cleanup step for macOS DMG resource busy error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,19 @@ jobs:
           # Clean up certificate file
           rm -f $RUNNER_TEMP/certificate.p12
 
+      - name: Clean up disk image processes (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # Kill any stale disk image helper processes that could cause "Resource busy" errors
+          pkill -9 diskimages-helper || true
+          pkill -9 hdiutil || true
+          # Detach any mounted disk images
+          for mount in $(hdiutil info 2>/dev/null | grep -E '^/dev/disk[0-9]+' | awk '{print $1}'); do
+            hdiutil detach "$mount" -force 2>/dev/null || true
+          done
+          # Small delay to ensure resources are released
+          sleep 2
+
       - name: Build and publish installers
         uses: tauri-apps/tauri-action@v0
         env:
@@ -460,6 +473,19 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm ci
+
+      - name: Clean up disk image processes (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # Kill any stale disk image helper processes that could cause "Resource busy" errors
+          pkill -9 diskimages-helper || true
+          pkill -9 hdiutil || true
+          # Detach any mounted disk images
+          for mount in $(hdiutil info 2>/dev/null | grep -E '^/dev/disk[0-9]+' | awk '{print $1}'); do
+            hdiutil detach "$mount" -force 2>/dev/null || true
+          done
+          # Small delay to ensure resources are released
+          sleep 2
 
       - name: Build Tauri bundle
         run: |


### PR DESCRIPTION
## Summary
- Fix the "hdiutil: create failed - Resource busy" error that's causing macOS releases to fail
- Add a cleanup step that kills stale disk image helper processes and detaches any mounted images before the Tauri build

## Root Cause
The GitHub Actions macOS runner sometimes has orphan `diskimages-helper` processes from previous runs that hold onto disk resources, causing `hdiutil create` to fail with "Resource busy".

## Changes
- Add "Clean up disk image processes (macOS)" step before both the release build and dry-run build
- This step kills `diskimages-helper` and `hdiutil` processes, detaches mounted disk images, and adds a short delay

## Test plan
- [ ] Merge this PR and trigger a new release
- [ ] Verify the macOS ARM64 build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)