### PR TITLE
fix: disable SMB for macOS builds due to code signing issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,12 +149,13 @@ jobs:
       matrix:
         include:
           # macOS Apple Silicon (M1/M2/M3)
+          # SMB disabled: pavao dynamically links libsmbclient which can't be code-signed for distribution
           - os: macos-15
             target: aarch64-apple-darwin
             arch: arm64
             rust-targets: aarch64-apple-darwin
-            smb: true
-          # macOS Intel (cross-compile from arm64 runner - no SMB due to cross-compile)
+            smb: false
+          # macOS Intel (cross-compile from arm64 runner)
           - os: macos-15
             target: x86_64-apple-darwin
             arch: x86_64
@@ -369,12 +370,13 @@ jobs:
       matrix:
         include:
           # macOS Apple Silicon (M1/M2/M3)
+          # SMB disabled: pavao dynamically links libsmbclient which can't be code-signed for distribution
           - os: macos-15
             target: aarch64-apple-darwin
             arch: arm64
             rust-targets: aarch64-apple-darwin
-            smb: true
-          # macOS Intel (cross-compile from arm64 runner - no SMB due to cross-compile)
+            smb: false
+          # macOS Intel (cross-compile from arm64 runner)
           - os: macos-15
             target: x86_64-apple-darwin
             arch: x86_64


### PR DESCRIPTION
## Summary
- Disable SMB feature for macOS builds to fix app crash at launch

## Root Cause
The `pavao` crate dynamically links to `libsmbclient`. When the signed/notarized app is distributed:
1. Users would need to install samba themselves (`brew install samba`)
2. Even if installed, macOS rejects the library due to Team ID mismatch between the app and the homebrew library

This causes the app to crash immediately at launch with:
```
Library not loaded: /opt/homebrew/*/libsmbclient.0.8.1.dylib
Reason: code signature not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs
```

## Changes
- Set `smb: false` for both macOS build targets (arm64 and x86_64)
- SMB support remains enabled for Linux builds where system library linking works fine

## Future Work
To enable SMB on macOS, we would need to either:
1. Vendor/bundle libsmbclient and sign it with the app's team ID
2. Use a different SMB library that supports static linking
3. Implement native macOS SMB support (without pavao)

## Test plan
- [ ] CI passes
- [ ] Merge and create new release
- [ ] Verify macOS app launches without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)