### PR TITLE
fix: add entitlement to allow loading libsmbclient for SMB support

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -14,6 +14,8 @@
         The pavao crate dynamically links to libsmbclient (installed via Homebrew),
         which is signed with a different Team ID. This entitlement allows the app
         to load libraries with different or missing signatures.
+        Tracking issue to remove this entitlement by bundling + re-signing libsmbclient:
+        https://github.com/StirlingMarketingGroup/marlin/issues/157
     -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>


### PR DESCRIPTION
## Summary
- Add `com.apple.security.cs.disable-library-validation` entitlement to allow loading differently-signed libraries
- This fixes the crash at launch when SMB support is enabled

## Root Cause
The `pavao` crate dynamically links to `libsmbclient` (from Homebrew). When the app is signed/notarized with our Team ID, macOS rejects the library because it's signed with a different Team ID.

## Solution
The `com.apple.security.cs.disable-library-validation` entitlement allows the app to load libraries that are signed with different Team IDs or are unsigned.

## Important Notes
1. **Users still need to install samba**: `brew install samba`
2. This entitlement reduces the security boundary slightly, but is necessary for dynamic library loading
3. The entitlement should pass notarization (Apple allows this for legitimate use cases)
4. **Packaged app PATH**: Finder-launched macOS apps often have a minimal PATH, so share enumeration now searches common Homebrew locations (e.g., `/opt/homebrew/bin`) for `smbclient` if it isn't found on PATH.

## Alternative approaches (not implemented)
- Bundling libsmbclient in the app and re-signing it (more complex)
- Using native macOS SMB APIs instead of pavao (significant rewrite)
- Static linking (not supported by pavao)

## Test plan
- [ ] CI passes
- [ ] Merge and create new release
- [ ] Download release and test with `brew install samba` installed
- [ ] Verify SMB shares work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Security follow-up
This PR uses `com.apple.security.cs.disable-library-validation` to unblock SMB on macOS.

Tracking issue to remove this entitlement by bundling + re-signing `libsmbclient` inside the app bundle: https://github.com/StirlingMarketingGroup/marlin/issues/157

