### PR TITLE
feat: add RAR archive extraction support

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,7 @@ notify = { version = "8.2", default-features = false, features = ["macos_fsevent
 walkdir = "2.5"
 libc = "0.2"
 zip = { version = "7.0", default-features = false, features = ["deflate", "bzip2", "zstd"] }
+unrar = "0.5"
 tar = "0.4"
 flate2 = "1.0"
 bzip2 = "0.6"

--- a/src/utils/fileTypes.ts
+++ b/src/utils/fileTypes.ts
@@ -18,7 +18,14 @@ export const ARCHIVE_EXTENSIONS = new Set([
   'lzma',
 ]);
 
-export type ExtractableArchiveFormat = 'zip' | 'tar' | 'tar.gz' | 'tar.bz2' | 'tar.xz' | 'tar.zst';
+export type ExtractableArchiveFormat =
+  | 'zip'
+  | 'rar'
+  | 'tar'
+  | 'tar.gz'
+  | 'tar.bz2'
+  | 'tar.xz'
+  | 'tar.zst';
 
 const EXTRACTABLE_ARCHIVE_PATTERNS: Array<{
   format: ExtractableArchiveFormat;
@@ -30,6 +37,7 @@ const EXTRACTABLE_ARCHIVE_PATTERNS: Array<{
   { format: 'tar.zst', patterns: ['.tar.zst', '.tzst'] },
   { format: 'tar', patterns: ['.tar'] },
   { format: 'zip', patterns: ['.zip'] },
+  { format: 'rar', patterns: ['.rar'] },
 ];
 
 export function isArchiveExtension(ext?: string | null): boolean {


### PR DESCRIPTION
## Summary

- Add RAR archive extraction support using the `unrar` crate
- Implement security hardening with path traversal protection for all archive types
- Add friendly error messages for password-protected and multi-volume RAR archives
- Remove system fallback extraction - show errors directly instead of silently falling back
- Make archive format hint matching case-insensitive

## Changes

### New Feature
- `src-tauri/Cargo.toml` - Add `unrar = "0.5"` dependency
- `src-tauri/src/commands.rs` - Add `Rar` variant to `ArchiveFormat` enum with full extraction support
- `src/utils/fileTypes.ts` - Add `'rar'` to `ExtractableArchiveFormat` type and patterns

### Security Improvements
- `src-tauri/src/commands.rs` - Add path traversal protection: reject entries with `..` components or absolute paths

### Error Handling
- `src-tauri/src/commands.rs` - Detect password-protected RAR archives and show friendly error
- `src-tauri/src/commands.rs` - Detect multi-volume archives and guide user to start from first part
- `src-tauri/src/commands.rs` - Make `archive_format_from_hint()` case-insensitive

### Code Cleanup
- `src-tauri/src/commands.rs` - Remove `extract_with_system()` functions (macOS ditto, Windows PowerShell, Linux unzip fallbacks)
- `src-tauri/src/commands.rs` - Simplify ZIP extraction to fail directly instead of attempting system fallback

## Test Plan

- [x] Extract a simple RAR archive (files extract correctly)
- [x] Extract RAR with subdirectories (directory structure preserved)
- [ ] Attempt to extract password-protected RAR (shows friendly error)
- [ ] Attempt to extract multi-volume RAR from wrong part (shows guidance)

## Notes

- The `unrar` crate uses UnRAR library bindings which has licensing considerations (free for decompression, restrictions on compression)
- RAR extraction is very fast thanks to native library
- Future: Could add support for `.cbr` (comic book RAR) extension

🤖 Generated with [Claude Code](https://claude.ai/code)