### PR TITLE
chore: migrate from cocoa crate to objc2 ecosystem

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,8 +51,6 @@ git2 = { version = "0.20", default-features = false, features = ["https", "vendo
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0"
 tokio = { version = "1.0", features = ["full"] }
-cocoa = { version = "0.26", optional = true }
-objc = { version = "0.2", optional = true }
 base64 = "0.22"
 # Thumbnail system dependencies
 image = { version = "0.25", features = ["png", "jpeg", "webp", "gif"] }
@@ -99,8 +97,9 @@ mime_guess = "2.0.5"
 rustls = { version = "0.23.32", features = ["ring"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = { version = "0.25" }
-objc = { version = "0.2" }
+objc2 = "0.6.3"
+objc2-foundation = "0.3.2"
+objc2-app-kit = "0.3.2"
 block = "0.1"
 tauri-plugin-macos-permissions = "2.3.0"
 

--- a/src-tauri/src/native_drag.rs
+++ b/src-tauri/src/native_drag.rs
@@ -1,58 +1,64 @@
 #![allow(unexpected_cfgs)]
 
 use base64::Engine as _;
-use cocoa::base::{id, nil, NO, YES};
-use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSSize, NSString};
-use objc::{class, msg_send, runtime::BOOL, sel, sel_impl};
+use objc2::class;
+use objc2::msg_send;
+use objc2::rc::autoreleasepool;
+use objc2::runtime::{AnyObject, Bool};
+use objc2_foundation::{NSArray, NSPoint, NSSize, NSString};
 
 pub fn start_native_drag(
     paths: Vec<String>,
     preview_image: Option<String>,
     _drag_offset_y: Option<f64>,
 ) -> Result<(), String> {
-    unsafe {
-        if paths.is_empty() {
-            return Err("No paths provided".into());
-        }
+    if paths.is_empty() {
+        return Err("No paths provided".into());
+    }
 
-        let _pool: id = NSAutoreleasePool::new(nil);
-
+    autoreleasepool(|_| unsafe {
         // Get NSApplication and key window
-        let ns_app: id = msg_send![class!(NSApplication), sharedApplication];
-        if ns_app == nil {
+        let ns_app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
+        if ns_app.is_null() {
             return Err("NSApplication unavailable".into());
         }
 
-        let window: id = msg_send![ns_app, keyWindow];
-        if window == nil {
+        let window: *mut AnyObject = msg_send![ns_app, keyWindow];
+        if window.is_null() {
             return Err("No key window".into());
         }
 
         // Get content view and find the deepest view under the cursor
-        let content_view: id = msg_send![window, contentView];
-        if content_view == nil {
+        let content_view: *mut AnyObject = msg_send![window, contentView];
+        if content_view.is_null() {
             return Err("No content view".into());
         }
 
         // Use mouseLocationOutsideOfEventStream for current mouse position
         let mouse_location_window: NSPoint = msg_send![window, mouseLocationOutsideOfEventStream];
-        let mouse_in_content: NSPoint =
-            msg_send![content_view, convertPoint: mouse_location_window fromView: nil];
+        let mouse_in_content: NSPoint = msg_send![
+            content_view,
+            convertPoint: mouse_location_window,
+            fromView: std::ptr::null_mut::<AnyObject>()
+        ];
 
         // Hit test to find the actual view under the cursor (likely WKWebView)
-        let hit_view: id = msg_send![content_view, hitTest: mouse_in_content];
-        let source_view: id = if hit_view != nil {
+        let hit_view: *mut AnyObject = msg_send![content_view, hitTest: mouse_in_content];
+        let source_view: *mut AnyObject = if !hit_view.is_null() {
             hit_view
         } else {
             content_view
         };
 
         // Convert mouse location to source view coordinates
-        let mouse_in_source: NSPoint =
-            msg_send![source_view, convertPoint: mouse_location_window fromView: nil];
+        let mouse_in_source: NSPoint = msg_send![
+            source_view,
+            convertPoint: mouse_location_window,
+            fromView: std::ptr::null_mut::<AnyObject>()
+        ];
 
         // Create drag image
-        let drag_img: id = if let Some(ref data_url) = preview_image {
+        let drag_img: *mut AnyObject = if let Some(ref data_url) = preview_image {
             match create_drag_image_from_data_url(data_url) {
                 Ok(img) => img,
                 Err(_) => create_drag_image_from_file_icon(&paths[0])?,
@@ -78,34 +84,39 @@ pub fn start_native_drag(
 
         // Use the deprecated but more reliable dragImage method for better positioning control
         // Create NSDragPboard with file paths
-        let drag_pboard_name: id = NSString::alloc(nil).init_str("NSDragPboard");
-        let pb: id = msg_send![class!(NSPasteboard), pasteboardWithName: drag_pboard_name];
+        let drag_pboard_name = NSString::from_str("NSDragPboard");
+        let pb: *mut AnyObject = msg_send![class!(NSPasteboard), pasteboardWithName: &*drag_pboard_name];
 
-        if pb == nil {
+        if pb.is_null() {
             return Err("Failed to create NSDragPboard".into());
         }
 
         // Clear and set pasteboard types
         let _: () = msg_send![pb, clearContents];
-        let nsfilenames_type: id = NSString::alloc(nil).init_str("NSFilenamesPboardType");
-        let types_array: id = msg_send![class!(NSArray), arrayWithObject: nsfilenames_type];
-        let _: BOOL = msg_send![pb, declareTypes: types_array owner: nil];
+        let nsfilenames_type = NSString::from_str("NSFilenamesPboardType");
+        let types_array = NSArray::from_retained_slice(&[nsfilenames_type.clone()]);
+        let _: i64 = msg_send![
+            pb,
+            declareTypes: &*types_array,
+            owner: std::ptr::null_mut::<AnyObject>()
+        ];
 
         // Create NSArray of file paths
-        let paths_array: id = msg_send![class!(NSMutableArray), array];
-        for path in &paths {
-            let path_nsstring: id = NSString::alloc(nil).init_str(path);
-            let _: () = msg_send![paths_array, addObject: path_nsstring];
-        }
+        let path_strings: Vec<_> = paths.iter().map(|path| NSString::from_str(path)).collect();
+        let paths_array = NSArray::from_retained_slice(&path_strings);
 
         // Set the paths on the pasteboard
-        let success: BOOL = msg_send![pb, setPropertyList: paths_array forType: nsfilenames_type];
-        if success == NO {
+        let success: Bool = msg_send![
+            pb,
+            setPropertyList: &*paths_array,
+            forType: &*nsfilenames_type
+        ];
+        if success.is_false() {
             return Err("Failed to set file paths on pasteboard".into());
         }
 
         // Get current event for the drag
-        let current_event: id = msg_send![ns_app, currentEvent];
+        let current_event: *mut AnyObject = msg_send![ns_app, currentEvent];
 
         // Calculate drag position - center the image exactly on the mouse cursor
         let drag_point = NSPoint::new(
@@ -114,23 +125,23 @@ pub fn start_native_drag(
         );
 
         // Use the deprecated but working dragImage method
-        let slide_back: BOOL = YES;
+        let slide_back = Bool::YES;
         let _: () = msg_send![
             source_view,
-            dragImage: drag_img
-            at: drag_point
-            offset: NSPoint::new(0.0, 0.0)
-            event: current_event
-            pasteboard: pb
-            source: source_view
+            dragImage: drag_img,
+            at: drag_point,
+            offset: NSPoint::new(0.0, 0.0),
+            event: current_event,
+            pasteboard: pb,
+            source: source_view,
             slideBack: slide_back
         ];
 
         Ok(())
-    }
+    })
 }
 
-fn create_drag_image_from_data_url(data_url: &str) -> Result<id, String> {
+fn create_drag_image_from_data_url(data_url: &str) -> Result<*mut AnyObject, String> {
     unsafe {
         // Extract base64 data
         let b64 = if let Some(idx) = data_url.find(',') {
@@ -138,6 +149,12 @@ fn create_drag_image_from_data_url(data_url: &str) -> Result<id, String> {
         } else {
             data_url
         };
+
+        // Add size limit to prevent DoS from huge payloads (max 50MB)
+        const MAX_ENCODED_SIZE: usize = 50 * 1024 * 1024;
+        if b64.len() > MAX_ENCODED_SIZE {
+            return Err("Image data too large".to_string());
+        }
 
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(b64)
@@ -148,14 +165,26 @@ fn create_drag_image_from_data_url(data_url: &str) -> Result<id, String> {
         }
 
         // Create NSData
-        let data: id = msg_send![class!(NSData), alloc];
-        let data: id = msg_send![data, initWithBytes: bytes.as_ptr() length: bytes.len()];
+        // Note: These objects are autoreleased within the surrounding autoreleasepool,
+        // which is fine since the drag operation completes within that scope.
+        let data: *mut AnyObject = msg_send![class!(NSData), alloc];
+        if data.is_null() {
+            return Err("Failed to allocate NSData".to_string());
+        }
+        let data: *mut AnyObject =
+            msg_send![data, initWithBytes: bytes.as_ptr(), length: bytes.len()];
+        if data.is_null() {
+            return Err("Failed to initialize NSData".to_string());
+        }
 
         // Create NSImage
-        let img: id = msg_send![class!(NSImage), alloc];
-        let img: id = msg_send![img, initWithData: data];
+        let img: *mut AnyObject = msg_send![class!(NSImage), alloc];
+        if img.is_null() {
+            return Err("Failed to allocate NSImage".to_string());
+        }
+        let img: *mut AnyObject = msg_send![img, initWithData: data];
 
-        if img == nil {
+        if img.is_null() {
             Err("Failed to create NSImage from data".to_string())
         } else {
             Ok(img)
@@ -163,13 +192,13 @@ fn create_drag_image_from_data_url(data_url: &str) -> Result<id, String> {
     }
 }
 
-fn create_drag_image_from_file_icon(path: &str) -> Result<id, String> {
+fn create_drag_image_from_file_icon(path: &str) -> Result<*mut AnyObject, String> {
     unsafe {
-        let path_nsstring: id = NSString::alloc(nil).init_str(path);
-        let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
-        let icon: id = msg_send![workspace, iconForFile: path_nsstring];
+        let path_nsstring = NSString::from_str(path);
+        let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+        let icon: *mut AnyObject = msg_send![workspace, iconForFile: &*path_nsstring];
 
-        if icon == nil {
+        if icon.is_null() {
             Err("Failed to get file icon".to_string())
         } else {
             Ok(icon)

--- a/src-tauri/src/plugins/drag_detector/macos.rs
+++ b/src-tauri/src/plugins/drag_detector/macos.rs
@@ -1,10 +1,11 @@
-use cocoa::appkit::{NSViewHeightSizable, NSViewWidthSizable, NSWindowOrderingMode};
-use cocoa::base::{id, nil, NO, YES};
-use cocoa::foundation::{NSArray, NSAutoreleasePool, NSPoint, NSRect, NSString};
-use objc::class;
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, BOOL};
-use objc::{msg_send, sel, sel_impl};
+use objc2::class;
+use objc2::ffi::NSUInteger;
+use objc2::msg_send;
+use objc2::rc::autoreleasepool;
+use objc2::runtime::{AnyClass, AnyObject, Bool, ClassBuilder, Sel};
+use objc2::sel;
+use objc2_app_kit::NSAutoresizingMaskOptions;
+use objc2_foundation::{NSPoint, NSRect, NSString};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::ffi::{c_void, CStr};
@@ -17,9 +18,14 @@ use super::{DragDropEvent, DragEventType, DropLocation, DropZoneConfig};
 
 type DragHandler = dyn Fn(DragDropEvent) + 'static;
 
-type NSDragOperation = u64;
+type NSDragOperation = NSUInteger;
 const NS_DRAG_OPERATION_NONE: NSDragOperation = 0;
 const NS_DRAG_OPERATION_COPY: NSDragOperation = 1;
+
+type Id = *mut AnyObject;
+
+// Static CStr for ivar name to avoid repeated parsing on hot path
+static IVAR_NAME: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"event_handler_ptr\0") };
 
 #[derive(Debug, Clone, Default)]
 struct DropZoneState {
@@ -32,60 +38,73 @@ static DROP_ZONES: Lazy<Mutex<HashMap<String, DropZoneState>>> =
 static INITIALIZED_WINDOWS: Lazy<Mutex<HashMap<String, bool>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
-static DRAG_OVERLAY_CLASS: Lazy<&'static Class> = Lazy::new(|| {
+static DRAG_OVERLAY_CLASS: Lazy<&'static AnyClass> = Lazy::new(|| {
     let superclass = class!(NSView);
-    let mut decl =
-        ClassDecl::new("MarlinDragOverlayView", superclass).expect("create overlay class");
+    let name = CStr::from_bytes_with_nul(b"MarlinDragOverlayView\0")
+        .expect("valid overlay class name");
+    let mut decl = ClassBuilder::new(name, superclass).expect("create overlay class");
 
     unsafe {
-        decl.add_ivar::<*mut c_void>("event_handler_ptr");
+        decl.add_ivar::<*mut c_void>(IVAR_NAME);
 
-        decl.add_method(
-            sel!(draggingEntered:),
-            dragging_entered as extern "C" fn(&Object, Sel, id) -> NSDragOperation,
-        );
+        let dragging_entered_fn: extern "C-unwind" fn(_, _, _) -> NSDragOperation =
+            dragging_entered;
+        decl.add_method(sel!(draggingEntered:), dragging_entered_fn);
 
-        decl.add_method(
-            sel!(draggingUpdated:),
-            dragging_updated as extern "C" fn(&Object, Sel, id) -> NSDragOperation,
-        );
+        let dragging_updated_fn: extern "C-unwind" fn(_, _, _) -> NSDragOperation =
+            dragging_updated;
+        decl.add_method(sel!(draggingUpdated:), dragging_updated_fn);
 
-        decl.add_method(
-            sel!(draggingExited:),
-            dragging_exited as extern "C" fn(&Object, Sel, id),
-        );
+        let dragging_exited_fn: extern "C-unwind" fn(_, _, _) = dragging_exited;
+        decl.add_method(sel!(draggingExited:), dragging_exited_fn);
 
-        decl.add_method(
-            sel!(performDragOperation:),
-            perform_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
-        );
+        let perform_drag_operation_fn: extern "C-unwind" fn(_, _, _) -> Bool =
+            perform_drag_operation;
+        decl.add_method(sel!(performDragOperation:), perform_drag_operation_fn);
 
-        decl.add_method(
-            sel!(prepareForDragOperation:),
-            prepare_for_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
-        );
+        let prepare_for_drag_operation_fn: extern "C-unwind" fn(_, _, _) -> Bool =
+            prepare_for_drag_operation;
+        decl.add_method(sel!(prepareForDragOperation:), prepare_for_drag_operation_fn);
 
         // Ensure normal pointer events pass through to the webview
-        decl.add_method(
-            sel!(hitTest:),
-            hit_test as extern "C" fn(&Object, Sel, NSPoint) -> id,
-        );
+        let hit_test_fn: extern "C-unwind" fn(_, _, _) -> Id = hit_test;
+        decl.add_method(sel!(hitTest:), hit_test_fn);
 
-        decl.add_method(
-            sel!(wantsPeriodicDraggingUpdates),
-            wants_periodic_dragging_updates as extern "C" fn(&Object, Sel) -> BOOL,
-        );
+        let wants_periodic_dragging_updates_fn: extern "C-unwind" fn(_, _) -> Bool =
+            wants_periodic_dragging_updates;
+        decl.add_method(sel!(wantsPeriodicDraggingUpdates), wants_periodic_dragging_updates_fn);
+
+        // Add dealloc to clean up the event handler and prevent memory leaks
+        let dealloc_fn: extern "C-unwind" fn(_, _) = overlay_dealloc;
+        decl.add_method(sel!(dealloc), dealloc_fn);
     }
 
     decl.register()
 });
 
-extern "C" fn dragging_entered(this: &Object, _sel: Sel, sender: id) -> NSDragOperation {
-    match catch_unwind(AssertUnwindSafe(|| unsafe {
-        let _pool = NSAutoreleasePool::new(nil);
-        let (event, target_id) = compose_event(sender, DragEventType::DragEnter);
-        emit_event(this, event);
-        drag_operation_for_target(&target_id)
+/// Dealloc method to free the event handler when the overlay is deallocated
+extern "C-unwind" fn overlay_dealloc(this: Id, _sel: Sel) {
+    unsafe {
+        if let Some(ivar) = (*this).class().instance_variable(IVAR_NAME) {
+            let handler_ptr = *ivar.load::<*mut c_void>(&*this);
+            if !handler_ptr.is_null() {
+                // Reclaim the Box to drop the Arc<DragHandler>
+                let _ = Box::from_raw(handler_ptr as *mut Arc<DragHandler>);
+            }
+        }
+        // Call superclass dealloc
+        let superclass = class!(NSView);
+        let _: () = msg_send![super(this, superclass), dealloc];
+    }
+}
+
+extern "C-unwind" fn dragging_entered(this: Id, _sel: Sel, sender: Id) -> NSDragOperation {
+    match catch_unwind(AssertUnwindSafe(|| {
+        autoreleasepool(|_| unsafe {
+            let (event, target_id) = compose_event(sender, DragEventType::DragEnter);
+            emit_event(&*this, event);
+            drag_operation_for_target(&target_id)
+        })
     })) {
         Ok(op) => op,
         Err(_) => {
@@ -95,12 +114,13 @@ extern "C" fn dragging_entered(this: &Object, _sel: Sel, sender: id) -> NSDragOp
     }
 }
 
-extern "C" fn dragging_updated(this: &Object, _sel: Sel, sender: id) -> NSDragOperation {
-    match catch_unwind(AssertUnwindSafe(|| unsafe {
-        let _pool = NSAutoreleasePool::new(nil);
-        let (event, target_id) = compose_event(sender, DragEventType::DragOver);
-        emit_event(this, event);
-        drag_operation_for_target(&target_id)
+extern "C-unwind" fn dragging_updated(this: Id, _sel: Sel, sender: Id) -> NSDragOperation {
+    match catch_unwind(AssertUnwindSafe(|| {
+        autoreleasepool(|_| unsafe {
+            let (event, target_id) = compose_event(sender, DragEventType::DragOver);
+            emit_event(&*this, event);
+            drag_operation_for_target(&target_id)
+        })
     })) {
         Ok(op) => op,
         Err(_) => {
@@ -110,71 +130,84 @@ extern "C" fn dragging_updated(this: &Object, _sel: Sel, sender: id) -> NSDragOp
     }
 }
 
-extern "C" fn dragging_exited(this: &Object, _sel: Sel, sender: id) {
-    if let Err(_) = catch_unwind(AssertUnwindSafe(|| unsafe {
-        let _pool = NSAutoreleasePool::new(nil);
-        let (event, _) = compose_event(sender, DragEventType::DragLeave);
-        emit_event(this, event);
+extern "C-unwind" fn dragging_exited(this: Id, _sel: Sel, sender: Id) {
+    if let Err(_) = catch_unwind(AssertUnwindSafe(|| {
+        autoreleasepool(|_| unsafe {
+            let (event, _) = compose_event(sender, DragEventType::DragLeave);
+            emit_event(&*this, event);
+        })
     })) {
         log::error!("dragging_exited panicked");
     }
 }
 
-extern "C" fn prepare_for_drag_operation(_this: &Object, _sel: Sel, _sender: id) -> BOOL {
-    YES
+extern "C-unwind" fn prepare_for_drag_operation(
+    _this: Id,
+    _sel: Sel,
+    _sender: Id,
+) -> Bool {
+    Bool::YES
 }
 
-extern "C" fn perform_drag_operation(this: &Object, _sel: Sel, sender: id) -> BOOL {
-    match catch_unwind(AssertUnwindSafe(|| unsafe {
-        let _pool = NSAutoreleasePool::new(nil);
-        let (event, target_id) = compose_event(sender, DragEventType::Drop);
+extern "C-unwind" fn perform_drag_operation(
+    this: Id,
+    _sel: Sel,
+    sender: Id,
+) -> Bool {
+    match catch_unwind(AssertUnwindSafe(|| {
+        autoreleasepool(|_| unsafe {
+            let (event, target_id) = compose_event(sender, DragEventType::Drop);
 
-        if !is_target_enabled(&target_id) {
-            return NO;
-        }
+            if !is_target_enabled(&target_id) {
+                return Bool::NO;
+            }
 
-        emit_event(this, event);
-        YES
+            emit_event(&*this, event);
+            Bool::YES
+        })
     })) {
         Ok(result) => result,
         Err(_) => {
             log::error!("perform_drag_operation panicked");
-            NO
+            Bool::NO
         }
     }
 }
 
-extern "C" fn hit_test(_this: &Object, _sel: Sel, _point: NSPoint) -> id {
+extern "C-unwind" fn hit_test(_this: Id, _sel: Sel, _point: NSPoint) -> Id {
     // Allow underlying views to handle normal events while still receiving drag callbacks
-    nil
+    std::ptr::null_mut()
 }
 
-extern "C" fn wants_periodic_dragging_updates(_this: &Object, _sel: Sel) -> BOOL {
-    YES
+extern "C-unwind" fn wants_periodic_dragging_updates(_this: Id, _sel: Sel) -> Bool {
+    Bool::YES
 }
 
-unsafe fn get_drag_location(sender: id) -> NSPoint {
+unsafe fn get_drag_location(sender: Id) -> NSPoint {
     msg_send![sender, draggingLocation]
 }
 
-unsafe fn get_dragged_paths(sender: id) -> Vec<String> {
-    let pasteboard: id = msg_send![sender, draggingPasteboard];
-    if pasteboard == nil {
+unsafe fn get_dragged_paths(sender: Id) -> Vec<String> {
+    let pasteboard: Id = msg_send![sender, draggingPasteboard];
+    if pasteboard.is_null() {
         return Vec::new();
     }
 
-    let url_class_ptr: *const Class = class!(NSURL);
-    let url_class_obj: id = url_class_ptr as *const _ as *mut Object;
-    let class_array: id = NSArray::arrayWithObject(nil, url_class_obj);
-    let urls: id = msg_send![pasteboard, readObjectsForClasses: class_array options: nil];
+    let url_class_ptr: &AnyClass = class!(NSURL);
+    let class_array: Id = msg_send![class!(NSArray), arrayWithObject: url_class_ptr];
+    let urls: Id = msg_send![
+        pasteboard,
+        readObjectsForClasses: class_array,
+        options: std::ptr::null_mut::<AnyObject>()
+    ];
 
     let mut paths = Vec::new();
 
-    if urls != nil {
+    if !urls.is_null() {
         let count: usize = msg_send![urls, count];
         for i in 0..count {
-            let url: id = msg_send![urls, objectAtIndex: i];
-            let path: id = msg_send![url, path];
+            let url: Id = msg_send![urls, objectAtIndex: i];
+            let path: Id = msg_send![url, path];
             let c_str: *const c_char = msg_send![path, UTF8String];
             if !c_str.is_null() {
                 if let Ok(path_str) = CStr::from_ptr(c_str).to_str() {
@@ -233,9 +266,13 @@ fn is_target_enabled(target: &Option<String>) -> bool {
     }
 }
 
-fn emit_event(this: &Object, event: DragDropEvent) {
+fn emit_event(this: &AnyObject, event: DragDropEvent) {
     unsafe {
-        let handler_ptr = *this.get_ivar::<*mut c_void>("event_handler_ptr");
+        let ivar = this
+            .class()
+            .instance_variable(IVAR_NAME)
+            .expect("overlay ivar missing");
+        let handler_ptr = *ivar.load::<*mut c_void>(this);
         if handler_ptr.is_null() {
             return;
         }
@@ -246,7 +283,7 @@ fn emit_event(this: &Object, event: DragDropEvent) {
     }
 }
 
-unsafe fn compose_event(sender: id, event_type: DragEventType) -> (DragDropEvent, Option<String>) {
+unsafe fn compose_event(sender: Id, event_type: DragEventType) -> (DragDropEvent, Option<String>) {
     let point = get_drag_location(sender);
     let paths = get_dragged_paths(sender);
     let target_id = match event_type {
@@ -271,20 +308,20 @@ unsafe fn compose_event(sender: id, event_type: DragEventType) -> (DragDropEvent
 fn install_overlay<R: Runtime>(window: Window<R>) -> Result<(), String> {
     unsafe {
         let ns_window_ptr = window.ns_window().map_err(|e| e.to_string())?;
-        let ns_window: id = ns_window_ptr as id;
-        let content_view: id = msg_send![ns_window, contentView];
-        if content_view == nil {
+        let ns_window: Id = ns_window_ptr as Id;
+        let content_view: Id = msg_send![ns_window, contentView];
+        if content_view.is_null() {
             return Err("No content view available".into());
         }
 
         let bounds: NSRect = msg_send![content_view, bounds];
 
-        let overlay: id = msg_send![*DRAG_OVERLAY_CLASS, alloc];
-        let overlay: id = msg_send![overlay, initWithFrame: bounds];
+        let overlay: Id = msg_send![*DRAG_OVERLAY_CLASS, alloc];
+        let overlay: Id = msg_send![overlay, initWithFrame: bounds];
         let _: () = msg_send![overlay, setAlphaValue: 0.0];
-        let _: () = msg_send![overlay, setHidden: NO];
+        let _: () = msg_send![overlay, setHidden: Bool::NO];
         let _: () =
-            msg_send![overlay, setAutoresizingMask: NSViewWidthSizable | NSViewHeightSizable];
+            msg_send![overlay, setAutoresizingMask: NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable];
 
         let handler_arc: Arc<DragHandler> = Arc::new({
             let window_clone = window.clone();
@@ -309,15 +346,26 @@ fn install_overlay<R: Runtime>(window: Window<R>) -> Result<(), String> {
 
         let handler_box = Box::new(handler_arc);
         let handler_ptr = Box::into_raw(handler_box) as *mut c_void;
-        let overlay_obj = overlay as *mut Object;
-        (*overlay_obj).set_ivar("event_handler_ptr", handler_ptr);
+        let overlay_obj = overlay as *mut AnyObject;
+        let ivar = (*overlay_obj)
+            .class()
+            .instance_variable(IVAR_NAME)
+            .expect("overlay ivar missing");
+        let slot = ivar.load_mut::<*mut c_void>(&mut *overlay_obj);
+        *slot = handler_ptr;
 
-        let ns_array: &Class = class!(NSArray);
-        let types: id =
-            msg_send![ns_array, arrayWithObject: NSString::alloc(nil).init_str("public.file-url")];
+        let types: Id = msg_send![
+            class!(NSArray),
+            arrayWithObject: &*NSString::from_str("public.file-url")
+        ];
         let _: () = msg_send![overlay, registerForDraggedTypes: types];
 
-        let _: () = msg_send![content_view, addSubview: overlay positioned: NSWindowOrderingMode::NSWindowAbove relativeTo: nil];
+        let _: () = msg_send![
+            content_view,
+            addSubview: overlay,
+            positioned: 1i64,
+            relativeTo: std::ptr::null_mut::<AnyObject>()
+        ];
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- Migrate all macOS native code from deprecated `cocoa` crate to the modern `objc2` ecosystem
- Replace `cocoa` (0.25/0.26) and `objc` (0.2) dependencies with `objc2`, `objc2-foundation`, and `objc2-app-kit`
- Fix memory leaks and add safety improvements found during multi-model code review (Claude Opus 4.5 + GPT-5.2)
- Eliminate 320+ deprecation warnings that were blocking CI with warnings-as-errors

Closes #191

## Changes

### Dependencies
- `src-tauri/Cargo.toml` - Replace `cocoa` and `objc` with `objc2` (0.6.3), `objc2-foundation` (0.3.2), `objc2-app-kit` (0.3.2)

### Clipboard Operations
- `src-tauri/src/clipboard.rs` - Migrate NSPasteboard, NSString, NSArray usage to objc2 APIs; use `autoreleasepool` for memory management; add null check for NSImage allocation

### File Operations
- `src-tauri/src/commands.rs` - Migrate NSFileManager, NSURL operations for trash/restore; add null checks for URL creation in `macos_restore_items` to prevent potential crashes

### Icon Extraction
- `src-tauri/src/macos_icons.rs` - Migrate NSWorkspace, NSImage icon extraction to objc2

### Security-Scoped Bookmarks
- `src-tauri/src/macos_security.rs` - Migrate security-scoped bookmark creation/resolution using `Retained<NSURL>` and `Retained<NSData>` for proper memory management

### Native Drag & Drop
- `src-tauri/src/native_drag.rs` - Migrate drag image creation and pasteboard operations; add 50MB size limit for base64 preview images to prevent DoS

### Drag Detector Plugin
- `src-tauri/src/plugins/drag_detector/macos.rs` - Migrate overlay view with proper `extern "C-unwind"` signatures; add `dealloc` method to free event handler and prevent memory leak; use static `IVAR_NAME` to avoid repeated CStr parsing on hot path

## Test Plan

- [x] `cargo build` passes with no errors
- [x] `npm run build` passes
- [x] `cargo check` with `-D warnings` passes (no deprecation warnings)
- [ ] Manual testing: Copy/paste files via clipboard
- [ ] Manual testing: Drag files from Finder into app
- [ ] Manual testing: Drag files from app to Finder
- [ ] Manual testing: Move files to trash and undo
- [ ] Manual testing: App icons display correctly

## Notes

The `objc2` crate provides better memory safety through Rust's type system while maintaining the same runtime behavior. The migration is a direct replacement of deprecated APIs - no behavioral changes intended.

🤖 Generated with [Claude Code](https://claude.ai/code)