### PR TITLE
feat: add VSCode-style new file flow with rename-on-create

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,7 @@ pub fn run() {
             commands::get_file_metadata,
             commands::resolve_symlink_parent_command,
             commands::create_folder,
+            commands::create_file,
             commands::create_nested_folders,
             commands::create_directory_command,
             commands::delete_file,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -79,12 +79,16 @@ pub fn create_menu<R: Runtime>(
     let new_folder_item = MenuItemBuilder::with_id("menu:new_folder", "New Folder")
         .accelerator("CmdOrCtrl+Shift+N")
         .build(app)?;
+    let new_file_item = MenuItemBuilder::with_id("menu:new_file", "New File")
+        .accelerator("CmdOrCtrl+Alt+N")
+        .build(app)?;
 
     // Create File submenu
     #[cfg(target_os = "macos")]
     let file_submenu = SubmenuBuilder::new(app, "File")
         .item(&new_window_item)
         .separator()
+        .item(&new_file_item)
         .item(&new_folder_item)
         .separator()
         .text("menu:refresh", "Refresh")
@@ -98,6 +102,7 @@ pub fn create_menu<R: Runtime>(
         .separator()
         .item(&preferences_item)
         .separator()
+        .item(&new_file_item)
         .item(&new_folder_item)
         .separator()
         .text("menu:refresh", "Refresh")
@@ -398,6 +403,9 @@ pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: &tauri::menu::Me
         }
         "menu:new_folder" => {
             let _ = app.emit("menu:new_folder", ());
+        }
+        "menu:new_file" => {
+            let _ = app.emit("menu:new_file", ());
         }
         "menu:new_window" => {
             let _ = app.emit("menu:new_window", ());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -902,6 +902,9 @@ function App() {
       await register('menu:rename', () => {
         useAppStore.getState().beginRenameSelected();
       });
+      await register('menu:new_file', () => {
+        void useAppStore.getState().createNewFile();
+      });
       await register('menu:new_folder', () => {
         void useAppStore.getState().createNewFolder();
       });
@@ -1431,8 +1434,17 @@ function App() {
         return;
       }
 
+      // New file: Cmd/Ctrl+Alt+N
+      if (!e.shiftKey && e.altKey && (e.key === 'n' || e.key === 'N')) {
+        if (!inEditable && !isRenaming && !hasModal) {
+          e.preventDefault();
+          void useAppStore.getState().createNewFile();
+        }
+        return;
+      }
+
       // New window: Cmd/Ctrl+N
-      if (!e.shiftKey && (e.key === 'n' || e.key === 'N')) {
+      if (!e.shiftKey && !e.altKey && (e.key === 'n' || e.key === 'N')) {
         e.preventDefault();
         const currentPath = useAppStore.getState().currentPath;
         invoke('new_window', { path: currentPath }).catch((err) => {

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -38,6 +38,7 @@ export default function ContextMenu({ x, y, isFileContext, onRequestClose }: Con
     cutSelectedFiles,
     pasteFiles,
     createNewFolder,
+    createNewFile,
     syncClipboardState,
     canPasteFiles,
     canPasteImage,
@@ -242,15 +243,26 @@ export default function ContextMenu({ x, y, isFileContext, onRequestClose }: Con
           </>
         )}
         {!isFileContext && (
-          <button
-            className="w-full text-left px-3 py-2 hover:bg-app-light"
-            onClick={() => {
-              onRequestClose();
-              void createNewFolder();
-            }}
-          >
-            New Folder
-          </button>
+          <>
+            <button
+              className="w-full text-left px-3 py-2 hover:bg-app-light"
+              onClick={() => {
+                onRequestClose();
+                void createNewFile();
+              }}
+            >
+              New File
+            </button>
+            <button
+              className="w-full text-left px-3 py-2 hover:bg-app-light"
+              onClick={() => {
+                onRequestClose();
+                void createNewFolder();
+              }}
+            >
+              New Folder
+            </button>
+          </>
         )}
         {/* Paste is always available */}
         <button

--- a/src/components/MainPanel.tsx
+++ b/src/components/MainPanel.tsx
@@ -201,6 +201,32 @@ export default function MainPanel() {
     setSelectedFiles([]);
   };
 
+  const handleContainerBackgroundDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('[data-file-item="true"]')) return;
+    if (
+      target.closest('button, a, input, select, textarea, [role="button"], [data-prevent-deselect]')
+    )
+      return;
+
+    const active = document.activeElement as HTMLElement | null;
+    const inEditable =
+      !!active &&
+      (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable);
+    if (inEditable) return;
+
+    const hasModal = !!document.querySelector(
+      '[role="dialog"], [aria-modal="true"], [data-modal="true"]'
+    );
+    if (hasModal) return;
+
+    const state = useAppStore.getState();
+    if (state.renameTargetPath) return;
+
+    e.preventDefault();
+    void state.createNewFile();
+  };
+
   const stopAutoScroll = () => {
     if (autoScrollFrameRef.current !== null) {
       cancelAnimationFrame(autoScrollFrameRef.current);
@@ -520,6 +546,7 @@ export default function MainPanel() {
         onContextMenuCapture={handleContextMenuCapture}
         onContextMenu={handleContextMenu}
         onClick={handleContainerBackgroundClick}
+        onDoubleClick={handleContainerBackgroundDoubleClick}
         onPointerDown={startMarquee}
       >
         {/* Mask old content while loading to avoid layout flicker during view changes */}


### PR DESCRIPTION
## Summary
- Add "New File" action accessible via Cmd/Ctrl+Alt+N, File menu, context menus, and double-click on blank area
- Backend creates files atomically with unique naming ("Untitled", "Untitled (1)", etc.)
- Newly created files immediately enter rename mode with proper cancel semantics
- VSCode-style nested path creation: typing `subdir/file.txt` creates parent directories atomically

Closes #207

## Changes

### Backend (Rust)
- `src-tauri/src/commands.rs` - Add `create_file` command with atomic creation using `OpenOptions::create_new(true)`, collision avoidance, security validation
- `src-tauri/src/commands.rs` - Add "New File" to native context menu (blank area)
- `src-tauri/src/lib.rs` - Register `create_file` command
- `src-tauri/src/menu.rs` - Add "New File" menu item with `CmdOrCtrl+Alt+N` accelerator

### Frontend (TypeScript/React)
- `src/App.tsx` - Register `menu:new_file` handler, add keyboard shortcut with input/rename/modal guards
- `src/components/ContextMenu.tsx` - Add "New File" option for blank area context menu
- `src/components/MainPanel.tsx` - Add double-click handler for blank area to create new file
- `src/store/useAppStore.ts` - Add `createNewFile()` action, update `cancelRename()` to handle files (delete only if empty)

## Test Plan
- [ ] File → New File works and shows keyboard shortcut
- [ ] Cmd+Alt+N (macOS) / Ctrl+Alt+N (Windows/Linux) creates new file
- [ ] Shortcut does not fire when focused on input fields or in rename mode
- [ ] Right-click on blank area shows "New File" in context menu
- [ ] Double-click on blank area creates new file
- [ ] New files get unique names: "Untitled", "Untitled (1)", "Untitled (2)", etc.
- [ ] Newly created file is selected and enters rename mode
- [ ] Escape during rename of just-created file deletes it (only if empty)
- [ ] Blur during rename of new file commits the name
- [ ] Typing `subdir/file.txt` when renaming creates nested directories and moves file
- [ ] Works in both grid and list views

🤖 Generated with [Claude Code](https://claude.com/claude-code)