### PR TITLE
[codex] Fix drive refresh and macOS folder access handling

### DIFF
--- a/e2e/drop-same-directory.spec.ts
+++ b/e2e/drop-same-directory.spec.ts
@@ -22,9 +22,57 @@ test.describe('Same-directory drops', () => {
     await page.evaluate(() => {
       const internals = window.__TAURI_INTERNALS__;
       const originalInvoke = internals.invoke;
-      window.__DROP_TEST__ = { pasteCalls: [] };
+      window.__DROP_TEST__ = {
+        nativeDropPathsOverride: null,
+        nativeDropTargetName: null,
+        pasteCalls: [],
+        startDragCalls: [],
+      };
 
       internals.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd === 'start_native_drag') {
+          window.__DROP_TEST__.startDragCalls.push(args);
+
+          return await new Promise((resolve) => {
+            setTimeout(() => {
+              const targetName = window.__DROP_TEST__.nativeDropTargetName;
+              const target =
+                targetName === null
+                  ? null
+                  : document.querySelector<HTMLElement>(
+                      `[data-testid="file-item"][data-name="${targetName}"]`
+                    );
+              const rect = target?.getBoundingClientRect();
+              const x = rect ? rect.left + rect.width / 2 : 200;
+              const clientY = rect ? rect.top + rect.height / 2 : 200;
+              const listeners = window.__TAURI_EVENT_LISTENERS__?.get('drag-drop-event') ?? [];
+              const dragArgs = args as { paths?: string[] } | undefined;
+              const payload = {
+                paths: window.__DROP_TEST__.nativeDropPathsOverride ?? dragArgs?.paths ?? [],
+                location: {
+                  x,
+                  y: window.innerHeight - clientY,
+                  targetId: 'file-panel',
+                },
+                eventType: 'drop',
+                modifiers: {
+                  optionAlt: false,
+                  cmdCtrl: false,
+                },
+              };
+
+              for (const handler of listeners) {
+                window.__TAURI_INTERNALS__.runCallback(handler, {
+                  event: 'drag-drop-event',
+                  payload,
+                });
+              }
+
+              resolve(undefined);
+            }, 50);
+          });
+        }
+
         if (cmd === 'paste_items_to_location') {
           window.__DROP_TEST__.pasteCalls.push(args);
           throw new Error('same-directory drops should not paste');
@@ -63,6 +111,51 @@ test.describe('Same-directory drops', () => {
     await page.waitForTimeout(300);
 
     await expect(page.getByText('Drop failed')).toHaveCount(0);
+
+    const pasteCalls = await page.evaluate(() => window.__DROP_TEST__.pasteCalls);
+    expect(pasteCalls).toEqual([]);
+  });
+
+  test('dragging a local file over another file in the same folder is a no-op', async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      window.__DROP_TEST__.nativeDropTargetName = 'sample.pdf';
+      window.__DROP_TEST__.nativeDropPathsOverride = ['/private/var/folders/mock/image.png'];
+    });
+
+    const source = page.locator('[data-testid="file-item"][data-name="image.png"]');
+    const target = page.locator('[data-testid="file-item"][data-name="sample.pdf"]');
+    await expect(source).toBeVisible();
+    await expect(target).toBeVisible();
+
+    const sourceBox = await source.boundingBox();
+    const targetBox = await target.boundingBox();
+    expect(sourceBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+
+    await page.mouse.move(
+      sourceBox!.x + sourceBox!.width / 2,
+      sourceBox!.y + sourceBox!.height / 2
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      sourceBox!.x + sourceBox!.width / 2 + 12,
+      sourceBox!.y + sourceBox!.height / 2 + 12
+    );
+    await page.mouse.move(
+      targetBox!.x + targetBox!.width / 2,
+      targetBox!.y + targetBox!.height / 2
+    );
+    await page.mouse.up();
+
+    await expect
+      .poll(() => page.evaluate(() => window.__DROP_TEST__.startDragCalls.length))
+      .toBe(1);
+    await page.waitForTimeout(300);
+
+    await expect(page.getByText('Drop failed')).toHaveCount(0);
+    await expect(page.getByText('Failed to validate drop')).toHaveCount(0);
 
     const pasteCalls = await page.evaluate(() => window.__DROP_TEST__.pasteCalls);
     expect(pasteCalls).toEqual([]);

--- a/e2e/drop-same-directory.spec.ts
+++ b/e2e/drop-same-directory.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { getTauriMockScript, MOCK_DOWNLOADS_DIR } from './tauri-mocks';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(getTauriMockScript());
+});
+
+test.describe('Same-directory drops', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+
+    const pathInput = page.locator('[data-testid="path-input"]');
+    await expect(pathInput).toBeVisible({ timeout: 15000 });
+    await pathInput.click();
+    await pathInput.fill(MOCK_DOWNLOADS_DIR);
+    await pathInput.press('Enter');
+
+    await expect(page.locator('[data-testid="file-item"][data-name="image.png"]')).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.evaluate(() => {
+      const internals = window.__TAURI_INTERNALS__;
+      const originalInvoke = internals.invoke;
+      window.__DROP_TEST__ = { pasteCalls: [] };
+
+      internals.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd === 'paste_items_to_location') {
+          window.__DROP_TEST__.pasteCalls.push(args);
+          throw new Error('same-directory drops should not paste');
+        }
+
+        return originalInvoke(cmd, args);
+      };
+    });
+  });
+
+  test('dropping a file back into its current folder is a no-op', async ({ page }) => {
+    await page.evaluate((filePath) => {
+      const listeners = window.__TAURI_EVENT_LISTENERS__?.get('drag-drop-event') ?? [];
+      const payload = {
+        paths: [filePath],
+        location: {
+          x: 200,
+          y: 200,
+          targetId: 'file-panel',
+        },
+        eventType: 'drop',
+        modifiers: {
+          optionAlt: false,
+          cmdCtrl: false,
+        },
+      };
+
+      for (const handler of listeners) {
+        window.__TAURI_INTERNALS__.runCallback(handler, {
+          event: 'drag-drop-event',
+          payload,
+        });
+      }
+    }, `${MOCK_DOWNLOADS_DIR}/image.png`);
+
+    await page.waitForTimeout(300);
+
+    await expect(page.getByText('Drop failed')).toHaveCount(0);
+
+    const pasteCalls = await page.evaluate(() => window.__DROP_TEST__.pasteCalls);
+    expect(pasteCalls).toEqual([]);
+  });
+});

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -187,8 +187,7 @@ mod macos {
                             msg_send![class!(NSBitmapImageRep), imageRepWithData: tiff_rep];
                         if !bitmap_rep.is_null() {
                             let png_type_num: u64 = 4; // NSBitmapImageFileTypePNG
-                            let props: *mut AnyObject =
-                                msg_send![class!(NSDictionary), dictionary];
+                            let props: *mut AnyObject = msg_send![class!(NSDictionary), dictionary];
                             let png_data: *mut AnyObject = msg_send![
                                 bitmap_rep,
                                 representationUsingType: png_type_num,
@@ -231,7 +230,8 @@ mod windows {
             return Err("No paths provided".into());
         }
 
-        let _clip = Clipboard::new_attempts(10).map_err(|e| format!("Failed to open clipboard: {}", e))?;
+        let _clip =
+            Clipboard::new_attempts(10).map_err(|e| format!("Failed to open clipboard: {}", e))?;
 
         // Build DROPFILES structure
         // Format: DROPFILES header followed by double-null-terminated wide string list
@@ -281,7 +281,8 @@ mod windows {
         // Copy paths
         let mut offset = header_size;
         for wide in &wide_paths {
-            let bytes = unsafe { std::slice::from_raw_parts(wide.as_ptr() as *const u8, wide.len() * 2) };
+            let bytes =
+                unsafe { std::slice::from_raw_parts(wide.as_ptr() as *const u8, wide.len() * 2) };
             buffer[offset..offset + bytes.len()].copy_from_slice(bytes);
             offset += bytes.len();
         }
@@ -293,7 +294,11 @@ mod windows {
             .map_err(|e| format!("Failed to write CF_HDROP: {}", e))?;
 
         // Set Preferred DropEffect
-        let effect: u32 = if is_cut { DROPEFFECT_MOVE } else { DROPEFFECT_COPY };
+        let effect: u32 = if is_cut {
+            DROPEFFECT_MOVE
+        } else {
+            DROPEFFECT_COPY
+        };
         let effect_bytes = effect.to_le_bytes();
 
         // Register and set "Preferred DropEffect" format
@@ -316,8 +321,11 @@ mod windows {
                     if !ptr.is_null() {
                         std::ptr::copy_nonoverlapping(effect_bytes.as_ptr(), ptr as *mut u8, 4);
                         GlobalUnlock(hmem);
-                        if SetClipboardData(format_id, windows::Win32::Foundation::HANDLE(hmem.0 as _))
-                            .is_err()
+                        if SetClipboardData(
+                            format_id,
+                            windows::Win32::Foundation::HANDLE(hmem.0 as _),
+                        )
+                        .is_err()
                         {
                             // `SetClipboardData` takes ownership on success; on failure we must free.
                             let _ = GlobalFree(hmem);
@@ -334,7 +342,8 @@ mod windows {
 
     /// Get clipboard contents information (Windows)
     pub fn get_clipboard_contents() -> Result<ClipboardInfo, String> {
-        let _clip = Clipboard::new_attempts(10).map_err(|e| format!("Failed to open clipboard: {}", e))?;
+        let _clip =
+            Clipboard::new_attempts(10).map_err(|e| format!("Failed to open clipboard: {}", e))?;
 
         let mut file_paths = Vec::new();
         let mut has_files = false;
@@ -427,7 +436,8 @@ mod windows {
 
     /// Get image data from clipboard as PNG bytes (Windows)
     pub fn get_clipboard_image() -> Result<Vec<u8>, String> {
-        let _clip = Clipboard::new_attempts(10).map_err(|e| format!("Failed to open clipboard: {}", e))?;
+        let _clip =
+            Clipboard::new_attempts(10).map_err(|e| format!("Failed to open clipboard: {}", e))?;
 
         // Get DIB data
         if let Ok(dib_data) = formats::CF_DIB.read_clipboard::<Vec<u8>>() {
@@ -443,7 +453,8 @@ mod windows {
                 // Reserved
                 bmp_data[6..10].copy_from_slice(&[0, 0, 0, 0]);
                 // Pixel data offset (after headers)
-                let header_size = u32::from_le_bytes([dib_data[0], dib_data[1], dib_data[2], dib_data[3]]);
+                let header_size =
+                    u32::from_le_bytes([dib_data[0], dib_data[1], dib_data[2], dib_data[3]]);
                 let pixel_offset = 14 + header_size;
                 bmp_data[10..14].copy_from_slice(&pixel_offset.to_le_bytes());
                 bmp_data[14..].copy_from_slice(&dib_data);
@@ -452,7 +463,10 @@ mod windows {
                 if let Ok(img) = image::load_from_memory(&bmp_data) {
                     let mut png_data = Vec::new();
                     if img
-                        .write_to(&mut std::io::Cursor::new(&mut png_data), image::ImageFormat::Png)
+                        .write_to(
+                            &mut std::io::Cursor::new(&mut png_data),
+                            image::ImageFormat::Png,
+                        )
                         .is_ok()
                     {
                         return Ok(png_data);
@@ -496,7 +510,12 @@ mod linux {
 
         // Try xclip first (most common)
         let xclip_result = Command::new("xclip")
-            .args(["-selection", "clipboard", "-t", "x-special/gnome-copied-files"])
+            .args([
+                "-selection",
+                "clipboard",
+                "-t",
+                "x-special/gnome-copied-files",
+            ])
             .stdin(std::process::Stdio::piped())
             .spawn();
 
@@ -551,7 +570,13 @@ mod linux {
 
         // Try x-special/gnome-copied-files first
         let gnome_result = Command::new("xclip")
-            .args(["-selection", "clipboard", "-t", "x-special/gnome-copied-files", "-o"])
+            .args([
+                "-selection",
+                "clipboard",
+                "-t",
+                "x-special/gnome-copied-files",
+                "-o",
+            ])
             .output();
 
         if let Ok(output) = gnome_result {
@@ -671,7 +696,10 @@ mod linux {
                 if let Ok(img) = image::load_from_memory(&output.stdout) {
                     let mut png_data = Vec::new();
                     if img
-                        .write_to(&mut std::io::Cursor::new(&mut png_data), image::ImageFormat::Png)
+                        .write_to(
+                            &mut std::io::Cursor::new(&mut png_data),
+                            image::ImageFormat::Png,
+                        )
                         .is_ok()
                     {
                         return Ok(png_data);
@@ -808,13 +836,12 @@ pub fn paste_files(destination: &str, is_cut: bool) -> Result<PasteResult, Strin
 
         let result = if should_move {
             // Move operation
-            std::fs::rename(source_path, &final_target)
-                .or_else(|_| {
-                    // If rename fails (cross-device), fall back to copy + delete
-                    std::fs::copy(source_path, &final_target)?;
-                    std::fs::remove_file(source_path)?;
-                    Ok::<_, std::io::Error>(())
-                })
+            std::fs::rename(source_path, &final_target).or_else(|_| {
+                // If rename fails (cross-device), fall back to copy + delete
+                std::fs::copy(source_path, &final_target)?;
+                std::fs::remove_file(source_path)?;
+                Ok::<_, std::io::Error>(())
+            })
         } else {
             // Copy operation
             std::fs::copy(source_path, &final_target).map(|_| ())
@@ -893,7 +920,10 @@ pub async fn clipboard_get_contents() -> Result<ClipboardInfo, String> {
 
 /// Paste files from clipboard to destination
 #[tauri::command]
-pub async fn clipboard_paste_files(destination: String, is_cut: bool) -> Result<PasteResult, String> {
+pub async fn clipboard_paste_files(
+    destination: String,
+    is_cut: bool,
+) -> Result<PasteResult, String> {
     tokio::task::spawn_blocking(move || paste_files(&destination, is_cut))
         .await
         .map_err(|e| format!("Task failed: {}", e))?

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,10 +7,10 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashSet;
-#[cfg(any(target_os = "windows", target_os = "linux"))]
-use std::ffi::OsString;
 #[cfg(target_os = "linux")]
 use std::env;
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use std::ffi::OsString;
 use std::fs;
 use std::io::{ErrorKind, Read, Seek, Write};
 use std::path::Path;
@@ -36,17 +36,19 @@ use crate::fs_utils::{
     resolve_symlink_parent, DiskUsage, FileItem, SymlinkResolution,
 };
 use crate::fs_watcher;
-use crate::locations::{resolve_location, Location, LocationCapabilities, LocationInput, LocationSummary};
+use crate::locations::gdrive::provider::{
+    download_file_to_temp, extract_gdrive_zip, fetch_url_with_auth, get_file_id_by_path,
+    get_folder_id_by_path, name_exists_in_folder, resolve_file_id_to_path, resolve_folder_id,
+    upload_file_to_gdrive,
+};
+use crate::locations::gdrive::url_parser::{is_google_drive_url, parse_google_drive_url};
 use crate::locations::gdrive::{
     add_google_account as add_gdrive_account, get_google_accounts as get_gdrive_accounts,
     remove_google_account as remove_gdrive_account, GoogleAccountInfo,
 };
-use crate::locations::gdrive::provider::{
-    download_file_to_temp, extract_gdrive_zip, fetch_url_with_auth, get_folder_id_by_path,
-    get_file_id_by_path, name_exists_in_folder, resolve_file_id_to_path, resolve_folder_id,
-    upload_file_to_gdrive,
+use crate::locations::{
+    resolve_location, Location, LocationCapabilities, LocationInput, LocationSummary,
 };
-use crate::locations::gdrive::url_parser::{is_google_drive_url, parse_google_drive_url};
 #[cfg(target_os = "macos")]
 use crate::macos_security;
 #[cfg(target_os = "macos")]
@@ -58,8 +60,8 @@ use crate::state::{
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
 use tar::Archive as TarArchive;
-use xz2::read::XzDecoder;
 use unrar::Archive as RarArchive;
+use xz2::read::XzDecoder;
 use zip::{ZipArchive, ZipWriter};
 use zstd::stream::read::Decoder as ZstdDecoder;
 
@@ -186,7 +188,10 @@ impl<T: Clone + Serialize> WindowPayloadQueue<T> {
             }
 
             if should_requeue {
-                let mut pending = self.pending.lock().expect("Failed to relock pending payload");
+                let mut pending = self
+                    .pending
+                    .lock()
+                    .expect("Failed to relock pending payload");
                 *pending = Some(payload);
             }
         }
@@ -210,22 +215,25 @@ static FOLDER_SIZE_QUEUE: Lazy<WindowPayloadQueue<FolderSizeInitPayload>> =
     Lazy::new(|| WindowPayloadQueue::new(FOLDER_SIZE_WINDOW_LABEL, FOLDER_SIZE_INIT_EVENT));
 static ARCHIVE_PROGRESS_QUEUE: Lazy<WindowPayloadQueue<ArchiveProgressPayload>> =
     Lazy::new(|| WindowPayloadQueue::new(ARCHIVE_PROGRESS_WINDOW_LABEL, ARCHIVE_PROGRESS_EVENT));
-static COMPRESS_PROGRESS_QUEUE: Lazy<WindowPayloadQueue<CompressProgressPayload>> = Lazy::new(
-    || WindowPayloadQueue::new(COMPRESS_PROGRESS_WINDOW_LABEL, COMPRESS_PROGRESS_INIT_EVENT),
-);
+static COMPRESS_PROGRESS_QUEUE: Lazy<WindowPayloadQueue<CompressProgressPayload>> =
+    Lazy::new(|| {
+        WindowPayloadQueue::new(COMPRESS_PROGRESS_WINDOW_LABEL, COMPRESS_PROGRESS_INIT_EVENT)
+    });
 static DELETE_PROGRESS_QUEUE: Lazy<WindowPayloadQueue<DeleteProgressPayload>> =
     Lazy::new(|| WindowPayloadQueue::new(DELETE_PROGRESS_WINDOW_LABEL, DELETE_PROGRESS_EVENT));
-static CLIPBOARD_PROGRESS_QUEUE: Lazy<WindowPayloadQueue<ClipboardProgressPayload>> = Lazy::new(
-    || WindowPayloadQueue::new(CLIPBOARD_PROGRESS_WINDOW_LABEL, CLIPBOARD_PROGRESS_EVENT),
-);
+static CLIPBOARD_PROGRESS_QUEUE: Lazy<WindowPayloadQueue<ClipboardProgressPayload>> =
+    Lazy::new(|| {
+        WindowPayloadQueue::new(CLIPBOARD_PROGRESS_WINDOW_LABEL, CLIPBOARD_PROGRESS_EVENT)
+    });
 static SMB_CONNECT_QUEUE: Lazy<WindowPayloadQueue<SmbConnectInitPayload>> =
     Lazy::new(|| WindowPayloadQueue::new(SMB_CONNECT_WINDOW_LABEL, SMB_CONNECT_INIT_EVENT));
 static SFTP_CONNECT_QUEUE: Lazy<WindowPayloadQueue<SftpConnectInitPayload>> =
     Lazy::new(|| WindowPayloadQueue::new(SFTP_CONNECT_WINDOW_LABEL, SFTP_CONNECT_INIT_EVENT));
 static CONFLICT_QUEUE: Lazy<WindowPayloadQueue<ConflictPayload>> =
     Lazy::new(|| WindowPayloadQueue::new(CONFLICT_WINDOW_LABEL, CONFLICT_INIT_EVENT));
-static CONFLICT_SENDER: Lazy<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<ConflictResolution>>>> =
-    Lazy::new(|| std::sync::Mutex::new(None));
+static CONFLICT_SENDER: Lazy<
+    std::sync::Mutex<Option<tokio::sync::oneshot::Sender<ConflictResolution>>>,
+> = Lazy::new(|| std::sync::Mutex::new(None));
 /// Stores the last conflict payload for re-delivery when React StrictMode
 /// remounts the conflict window component (mount→unmount→remount in dev).
 static CONFLICT_PENDING_PAYLOAD: Lazy<std::sync::Mutex<Option<ConflictPayload>>> =
@@ -374,9 +382,8 @@ fn macos_trash_items(paths: &[PathBuf]) -> Result<Vec<MacTrashUndoItem>, String>
                 ));
             }
 
-            let trashed_path = nsurl_path(resulting_url).ok_or_else(|| {
-                String::from("Failed to resolve trash destination path")
-            })?;
+            let trashed_path = nsurl_path(resulting_url)
+                .ok_or_else(|| String::from("Failed to resolve trash destination path"))?;
 
             let trashed_path_buf = Path::new(&trashed_path).to_path_buf();
             macos_security::persist_bookmark(&trashed_path_buf, "trashing item");
@@ -1360,7 +1367,10 @@ pub struct DropOperationInfo {
 
 fn is_remote_fs(fs_type: &str) -> bool {
     let lower = fs_type.to_lowercase();
-    lower.contains("smb") || lower.contains("nfs") || lower.contains("afp") || lower.contains("webdav")
+    lower.contains("smb")
+        || lower.contains("nfs")
+        || lower.contains("afp")
+        || lower.contains("webdav")
 }
 
 #[command]
@@ -1379,33 +1389,33 @@ pub async fn resolve_drop_operation(
 
     // Validation
     let dest_canon = dest_path.canonicalize().ok();
-    
+
     if let Some(ref d_canon) = dest_canon {
         for source in &sources {
             let source_path_buf = match fs_utils::expand_path(source) {
                 Ok(p) => p,
                 Err(_) => continue,
             };
-            
+
             if let Ok(s_canon) = source_path_buf.canonicalize() {
                 // Cannot drop item onto itself
                 if s_canon == *d_canon {
-                     return Ok(DropOperationInfo {
-                         operation: "none".to_string(),
-                         is_remote: false,
-                         valid: false,
-                         reason: Some("Cannot drop item onto itself".to_string()),
-                     });
+                    return Ok(DropOperationInfo {
+                        operation: "none".to_string(),
+                        is_remote: false,
+                        valid: false,
+                        reason: Some("Cannot drop item onto itself".to_string()),
+                    });
                 }
-                
+
                 // Cannot drop folder into itself or descendant
                 if source_path_buf.is_dir() && d_canon.starts_with(&s_canon) {
-                      return Ok(DropOperationInfo {
-                         operation: "none".to_string(),
-                         is_remote: false,
-                         valid: false,
-                         reason: Some("Cannot drop folder into itself".to_string()),
-                     });
+                    return Ok(DropOperationInfo {
+                        operation: "none".to_string(),
+                        is_remote: false,
+                        valid: false,
+                        reason: Some("Cannot drop folder into itself".to_string()),
+                    });
                 }
             }
         }
@@ -1545,6 +1555,11 @@ pub async fn read_directory_streaming_command(
         return Err("Path is not a directory".to_string());
     }
 
+    #[cfg(target_os = "macos")]
+    let _scope_guard = macos_security::retain_access(&expanded_path)?;
+
+    fs::read_dir(&expanded_path).map_err(|e| format!("Failed to read directory: {}", e))?;
+
     // Use the session_id provided by the frontend
     let cancel_flag = Arc::new(AtomicBool::new(false));
 
@@ -1617,6 +1632,31 @@ pub async fn read_directory_streaming_command(
         location: location_summary,
         capabilities,
     })
+}
+
+#[command]
+pub fn authorize_folder_access(path: String) -> Result<(), String> {
+    let path_buf = expand_path(&path)?;
+
+    if !path_buf.exists() {
+        return Err("Path does not exist".to_string());
+    }
+
+    if !path_buf.is_dir() {
+        return Err("Path is not a directory".to_string());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        macos_security::store_bookmark_if_needed(&path_buf)?;
+        let _scope_guard = macos_security::retain_access(&path_buf)?;
+        fs::read_dir(&path_buf).map_err(|e| format!("Failed to read directory: {}", e))?;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fs::read_dir(&path_buf).map_err(|e| format!("Failed to read directory: {}", e))?;
+
+    Ok(())
 }
 
 /// Cancel an active directory streaming session
@@ -1909,10 +1949,7 @@ pub fn create_nested_folders(base_dir: String, nested_path: String) -> Result<St
     }
 
     // Split into segments and validate each
-    let segments: Vec<&str> = normalized
-        .split('/')
-        .filter(|s| !s.is_empty())
-        .collect();
+    let segments: Vec<&str> = normalized.split('/').filter(|s| !s.is_empty()).collect();
 
     if segments.is_empty() {
         return Err("Nested path cannot be empty".to_string());
@@ -1997,17 +2034,17 @@ pub async fn trash_paths(app: AppHandle, paths: Vec<String>) -> Result<TrashPath
     // Capture trash state BEFORE deletion on Windows/Linux for undo tracking
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     let before_ids: HashSet<OsString> = {
-        let before =
-            os_limited::list().map_err(|err| format!("Failed to inspect trash: {err}"))?;
+        let before = os_limited::list().map_err(|err| format!("Failed to inspect trash: {err}"))?;
         before.into_iter().map(|item| item.id).collect()
     };
 
     #[cfg(target_os = "macos")]
     let mac_records = {
         let task_paths = delete_targets.clone();
-        let task_result = tauri::async_runtime::spawn_blocking(move || macos_trash_items(&task_paths))
-            .await
-            .map_err(|err| format!("Failed to join trash task: {err}"))?;
+        let task_result =
+            tauri::async_runtime::spawn_blocking(move || macos_trash_items(&task_paths))
+                .await
+                .map_err(|err| format!("Failed to join trash task: {err}"))?;
 
         match task_result {
             Ok(records) => records,
@@ -2027,11 +2064,10 @@ pub async fn trash_paths(app: AppHandle, paths: Vec<String>) -> Result<TrashPath
 
     #[cfg(not(target_os = "macos"))]
     {
-        let delete_result = tauri::async_runtime::spawn_blocking(move || {
-            trash::delete_all(delete_targets.iter())
-        })
-        .await
-        .map_err(|err| format!("Failed to join trash task: {err}"))?;
+        let delete_result =
+            tauri::async_runtime::spawn_blocking(move || trash::delete_all(delete_targets.iter()))
+                .await
+                .map_err(|err| format!("Failed to join trash task: {err}"))?;
 
         if let Err(err) = delete_result {
             return Err(err.to_string());
@@ -2343,7 +2379,12 @@ fn join_dest_raw(dest_scheme: &str, dest_dir_raw: &str, name: &str) -> String {
     }
 }
 
-fn emit_clipboard_progress_init(app: &AppHandle, operation: String, destination: String, total: usize) {
+fn emit_clipboard_progress_init(
+    app: &AppHandle,
+    operation: String,
+    destination: String,
+    total: usize,
+) {
     emit_clipboard_progress_update(
         app,
         ClipboardProgressUpdatePayload {
@@ -2432,7 +2473,10 @@ pub async fn paste_items_to_location(
     let dest_dir_path: Option<PathBuf> = if dest_scheme == "file" {
         let p = PathBuf::from(&dest_dir_raw);
         if !p.exists() {
-            return Err(format!("Destination does not exist: {}", p.to_string_lossy()));
+            return Err(format!(
+                "Destination does not exist: {}",
+                p.to_string_lossy()
+            ));
         }
         if !p.is_dir() {
             return Err(format!(
@@ -2450,7 +2494,12 @@ pub async fn paste_items_to_location(
     } else {
         "Copying items".to_string()
     };
-    emit_clipboard_progress_init(&app, operation_label.clone(), dest_dir_raw.clone(), total_items);
+    emit_clipboard_progress_init(
+        &app,
+        operation_label.clone(),
+        dest_dir_raw.clone(),
+        total_items,
+    );
 
     let mut pasted_paths: Vec<String> = Vec::new();
     let mut skipped_count = 0usize;
@@ -2507,302 +2556,409 @@ pub async fn paste_items_to_location(
 
         emit_clipboard_progress_item(&app, Some(name.clone()), completed, total_items, None);
 
-        log::debug!("paste_items_to_location: source_scheme={}, dest_scheme={}, name={}", source_scheme, dest_scheme, name);
-        let result: Result<Option<String>, String> = match (source_scheme.as_str(), dest_scheme.as_str()) {
-            ("file", "file") => {
-                let Some(dest_dir) = dest_dir_path.as_ref() else {
-                    return Err("Local destination directory is required".to_string());
-                };
-                let candidate = dest_dir.join(&name);
-                let source_path = PathBuf::from(source_location.to_path_string());
+        log::debug!(
+            "paste_items_to_location: source_scheme={}, dest_scheme={}, name={}",
+            source_scheme,
+            dest_scheme,
+            name
+        );
+        let result: Result<Option<String>, String> =
+            match (source_scheme.as_str(), dest_scheme.as_str()) {
+                ("file", "file") => {
+                    let Some(dest_dir) = dest_dir_path.as_ref() else {
+                        return Err("Local destination directory is required".to_string());
+                    };
+                    let candidate = dest_dir.join(&name);
+                    let source_path = PathBuf::from(source_location.to_path_string());
 
-                if candidate.exists() {
-                    // Conflict detected — resolve it
-                    let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
-                        (stored.clone(), None)
-                    } else {
-                        conflict_index += 1;
-                        let remaining = total_items.saturating_sub(completed + 1);
-                        let source_info = build_local_conflict_info(&source_path)?;
-                        let dest_info = build_local_conflict_info(&candidate)?;
-                        match ask_user_about_conflict(
-                            &app, source_info, dest_info,
-                            conflict_index, remaining, operation_str,
-                        ).await {
-                            Ok(resolution) => {
-                                let a = resolution.action.clone();
-                                let cn = resolution.custom_name.clone();
-                                if resolution.apply_to_all {
-                                    apply_to_all_action = Some(resolution.action);
+                    if candidate.exists() {
+                        // Conflict detected — resolve it
+                        let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
+                            (stored.clone(), None)
+                        } else {
+                            conflict_index += 1;
+                            let remaining = total_items.saturating_sub(completed + 1);
+                            let source_info = build_local_conflict_info(&source_path)?;
+                            let dest_info = build_local_conflict_info(&candidate)?;
+                            match ask_user_about_conflict(
+                                &app,
+                                source_info,
+                                dest_info,
+                                conflict_index,
+                                remaining,
+                                operation_str,
+                            )
+                            .await
+                            {
+                                Ok(resolution) => {
+                                    let a = resolution.action.clone();
+                                    let cn = resolution.custom_name.clone();
+                                    if resolution.apply_to_all {
+                                        apply_to_all_action = Some(resolution.action);
+                                    }
+                                    (a, cn)
                                 }
-                                (a, cn)
-                            }
-                            Err(e) if e == "CONFLICT_CANCELLED" => {
-                                cancelled = true;
-                                skipped_count += 1;
-                                completed += 1;
-                                emit_clipboard_progress_item(&app, None, completed, total_items, None);
-                                continue;
-                            }
-                            Err(e) => return Err(e),
-                        }
-                    };
-
-                    execute_local_conflict_action(
-                        &action,
-                        custom_name.as_deref(),
-                        &source_path,
-                        dest_dir,
-                        &name,
-                        is_cut,
-                        source_provider.as_ref(),
-                        &source_location,
-                    ).await
-                } else {
-                    // No conflict — proceed normally
-                    let dest_raw = candidate.to_string_lossy().to_string();
-                    let (_, dest_item_location) = resolve_location(LI::Raw(dest_raw.clone()))?;
-                    if is_cut {
-                        source_provider.move_item(&source_location, &dest_item_location).await?;
-                    } else {
-                        source_provider.copy(&source_location, &dest_item_location).await?;
-                    }
-                    Ok(Some(dest_raw))
-                }
-            }
-            (src, dst) if src == dst => {
-                let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &name);
-                let (dest_provider, dest_item_location) = resolve_location(LI::Raw(dest_raw.clone()))?;
-
-                // Check if destination already exists via provider metadata — reuse result for conflict info
-                let dest_meta_result = dest_provider.get_file_metadata(&dest_item_location).await;
-                let dest_exists = dest_meta_result.is_ok();
-
-                if dest_exists {
-                    let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
-                        (stored.clone(), None)
-                    } else {
-                        conflict_index += 1;
-                        let remaining = total_items.saturating_sub(completed + 1);
-                        // Build source info from provider metadata
-                        let source_meta = source_provider.get_file_metadata(&source_location).await;
-                        let source_info = match source_meta {
-                            Ok(meta) => ConflictFileInfo {
-                                name: meta.name.clone(),
-                                path: source_location.raw().to_string(),
-                                size: meta.size,
-                                modified: meta.modified.to_rfc3339(),
-                                is_directory: meta.is_directory,
-                                extension: meta.extension.clone(),
-                            },
-                            Err(_) => ConflictFileInfo {
-                                name: name.clone(),
-                                path: source_location.raw().to_string(),
-                                size: 0,
-                                modified: String::new(),
-                                is_directory: false,
-                                extension: Path::new(&name).extension().and_then(|e| e.to_str()).map(|s| s.to_string()),
-                            },
-                        };
-                        // Reuse the metadata we already fetched for existence check
-                        let dest_info = match dest_meta_result {
-                            Ok(ref meta) => ConflictFileInfo {
-                                name: meta.name.clone(),
-                                path: dest_raw.clone(),
-                                size: meta.size,
-                                modified: meta.modified.to_rfc3339(),
-                                is_directory: meta.is_directory,
-                                extension: meta.extension.clone(),
-                            },
-                            Err(_) => ConflictFileInfo {
-                                name: name.clone(),
-                                path: dest_raw.clone(),
-                                size: 0,
-                                modified: String::new(),
-                                is_directory: false,
-                                extension: Path::new(&name).extension().and_then(|e| e.to_str()).map(|s| s.to_string()),
-                            },
-                        };
-                        match ask_user_about_conflict(
-                            &app, source_info, dest_info,
-                            conflict_index, remaining, operation_str,
-                        ).await {
-                            Ok(res) => {
-                                let a = res.action.clone();
-                                let cn = res.custom_name.clone();
-                                if res.apply_to_all { apply_to_all_action = Some(res.action); }
-                                (a, cn)
-                            }
-                            Err(e) if e == "CONFLICT_CANCELLED" => {
-                                cancelled = true;
-                                skipped_count += 1;
-                                completed += 1;
-                                emit_clipboard_progress_item(&app, None, completed, total_items, None);
-                                continue;
-                            }
-                            Err(e) => return Err(e),
-                        }
-                    };
-                    match action {
-                        ConflictAction::Skip => Ok(None),
-                        ConflictAction::Replace => {
-                            // Guard: don't delete+copy if source and dest are the same location
-                            if source_location.raw() == dest_item_location.raw() {
-                                Ok(Some(dest_raw))
-                            } else {
-                                let _ = dest_provider.delete(&dest_item_location).await;
-                                let op = if is_cut {
-                                    source_provider.move_item(&source_location, &dest_item_location).await
-                                } else {
-                                    source_provider.copy(&source_location, &dest_item_location).await
-                                };
-                                op.map(|()| Some(dest_raw))
-                            }
-                        }
-                        // Merge not supported for remote providers — fall back to KeepBoth
-                        ConflictAction::Merge | ConflictAction::KeepBoth => {
-                            let stem = Path::new(&name).file_stem().and_then(|s| s.to_str()).unwrap_or(&name);
-                            let ext = Path::new(&name).extension().and_then(|e| e.to_str());
-                            let mut resolved: Option<String> = None;
-                            for i in 2..1000usize {
-                                let candidate_name = if let Some(e) = ext {
-                                    format!("{stem} ({i}).{e}")
-                                } else {
-                                    format!("{stem} ({i})")
-                                };
-                                let candidate_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &candidate_name);
-                                let (_, candidate_loc) = resolve_location(LI::Raw(candidate_raw.clone()))?;
-                                if dest_provider.get_file_metadata(&candidate_loc).await.is_err() {
-                                    let op = if is_cut {
-                                        source_provider.move_item(&source_location, &candidate_loc).await
-                                    } else {
-                                        source_provider.copy(&source_location, &candidate_loc).await
-                                    };
-                                    op?;
-                                    resolved = Some(candidate_raw);
-                                    break;
+                                Err(e) if e == "CONFLICT_CANCELLED" => {
+                                    cancelled = true;
+                                    skipped_count += 1;
+                                    completed += 1;
+                                    emit_clipboard_progress_item(
+                                        &app,
+                                        None,
+                                        completed,
+                                        total_items,
+                                        None,
+                                    );
+                                    continue;
                                 }
+                                Err(e) => return Err(e),
                             }
-                            match resolved {
-                                Some(path) => Ok(Some(path)),
-                                None => Err("Unable to allocate unique destination name after 999 attempts".to_string()),
-                            }
-                        }
-                        ConflictAction::Rename => {
-                            let raw_name = custom_name.ok_or("Rename requires a custom name")?;
-                            let safe_name = sanitize_conflict_name(&raw_name)?;
-                            let renamed_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &safe_name);
-                            let (rp, renamed_location) = resolve_location(LI::Raw(renamed_raw.clone()))?;
-                            // Check if the renamed target already exists
-                            if rp.get_file_metadata(&renamed_location).await.is_ok() {
-                                return Err(format!("A file named '{safe_name}' already exists"));
-                            }
-                            let op = if is_cut {
-                                source_provider.move_item(&source_location, &renamed_location).await
-                            } else {
-                                source_provider.copy(&source_location, &renamed_location).await
-                            };
-                            op.map(|()| Some(renamed_raw))
-                        }
-                    }
-                } else {
-                    let op = if is_cut {
-                        source_provider.move_item(&source_location, &dest_item_location).await
+                        };
+
+                        execute_local_conflict_action(
+                            &action,
+                            custom_name.as_deref(),
+                            &source_path,
+                            dest_dir,
+                            &name,
+                            is_cut,
+                            source_provider.as_ref(),
+                            &source_location,
+                        )
+                        .await
                     } else {
-                        source_provider.copy(&source_location, &dest_item_location).await
-                    };
-                    op.map(|()| Some(dest_raw))
+                        // No conflict — proceed normally
+                        let dest_raw = candidate.to_string_lossy().to_string();
+                        let (_, dest_item_location) = resolve_location(LI::Raw(dest_raw.clone()))?;
+                        if is_cut {
+                            source_provider
+                                .move_item(&source_location, &dest_item_location)
+                                .await?;
+                        } else {
+                            source_provider
+                                .copy(&source_location, &dest_item_location)
+                                .await?;
+                        }
+                        Ok(Some(dest_raw))
+                    }
                 }
-            }
-            ("file", "gdrive") => {
-                let email = dest_location
-                    .authority()
-                    .ok_or_else(|| "Google Drive destination missing account".to_string())?;
-                let folder_id = get_folder_id_by_path(email, dest_location.path()).await?;
-                let local_path = PathBuf::from(source_location.to_path_string());
-                if !local_path.exists() || !local_path.is_file() {
-                    Ok(None)
-                } else {
-                    upload_file_to_gdrive(email, &local_path, &folder_id, &name).await?;
+                (src, dst) if src == dst => {
                     let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &name);
-                    if is_cut {
-                        if let Err(e) = fs::remove_file(&local_path) {
-                            last_error = Some(format!("Uploaded but failed to delete source: {e}"));
-                        }
-                    }
-                    Ok(Some(dest_raw))
-                }
-            }
-            ("gdrive", "file") => {
-                let Some(dest_dir) = dest_dir_path.as_ref() else {
-                    return Err("Local destination directory is required".to_string());
-                };
-                let email = source_location
-                    .authority()
-                    .ok_or_else(|| "Google Drive source missing account".to_string())?;
-                let file_id = get_file_id_by_path(email, source_location.path()).await?;
-                let temp_path = download_file_to_temp(email, &file_id, &name).await?;
+                    let (dest_provider, dest_item_location) =
+                        resolve_location(LI::Raw(dest_raw.clone()))?;
 
-                let candidate = dest_dir.join(&name);
-                let op_result = if candidate.exists() {
-                    // Conflict
-                    let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
-                        (stored.clone(), None)
-                    } else {
-                        conflict_index += 1;
-                        let remaining = total_items.saturating_sub(completed + 1);
-                        let mut source_info = build_local_conflict_info(Path::new(&temp_path))?;
-                        // Override temp filename/path with real Google Drive name
-                        source_info.name = name.clone();
-                        source_info.path = source_location.raw().to_string();
-                        let dest_info = build_local_conflict_info(&candidate)?;
-                        match ask_user_about_conflict(
-                            &app, source_info, dest_info,
-                            conflict_index, remaining, operation_str,
-                        ).await {
-                            Ok(res) => {
-                                let a = res.action.clone();
-                                let cn = res.custom_name.clone();
-                                if res.apply_to_all { apply_to_all_action = Some(res.action); }
-                                (a, cn)
+                    // Check if destination already exists via provider metadata — reuse result for conflict info
+                    let dest_meta_result =
+                        dest_provider.get_file_metadata(&dest_item_location).await;
+                    let dest_exists = dest_meta_result.is_ok();
+
+                    if dest_exists {
+                        let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
+                            (stored.clone(), None)
+                        } else {
+                            conflict_index += 1;
+                            let remaining = total_items.saturating_sub(completed + 1);
+                            // Build source info from provider metadata
+                            let source_meta =
+                                source_provider.get_file_metadata(&source_location).await;
+                            let source_info = match source_meta {
+                                Ok(meta) => ConflictFileInfo {
+                                    name: meta.name.clone(),
+                                    path: source_location.raw().to_string(),
+                                    size: meta.size,
+                                    modified: meta.modified.to_rfc3339(),
+                                    is_directory: meta.is_directory,
+                                    extension: meta.extension.clone(),
+                                },
+                                Err(_) => ConflictFileInfo {
+                                    name: name.clone(),
+                                    path: source_location.raw().to_string(),
+                                    size: 0,
+                                    modified: String::new(),
+                                    is_directory: false,
+                                    extension: Path::new(&name)
+                                        .extension()
+                                        .and_then(|e| e.to_str())
+                                        .map(|s| s.to_string()),
+                                },
+                            };
+                            // Reuse the metadata we already fetched for existence check
+                            let dest_info = match dest_meta_result {
+                                Ok(ref meta) => ConflictFileInfo {
+                                    name: meta.name.clone(),
+                                    path: dest_raw.clone(),
+                                    size: meta.size,
+                                    modified: meta.modified.to_rfc3339(),
+                                    is_directory: meta.is_directory,
+                                    extension: meta.extension.clone(),
+                                },
+                                Err(_) => ConflictFileInfo {
+                                    name: name.clone(),
+                                    path: dest_raw.clone(),
+                                    size: 0,
+                                    modified: String::new(),
+                                    is_directory: false,
+                                    extension: Path::new(&name)
+                                        .extension()
+                                        .and_then(|e| e.to_str())
+                                        .map(|s| s.to_string()),
+                                },
+                            };
+                            match ask_user_about_conflict(
+                                &app,
+                                source_info,
+                                dest_info,
+                                conflict_index,
+                                remaining,
+                                operation_str,
+                            )
+                            .await
+                            {
+                                Ok(res) => {
+                                    let a = res.action.clone();
+                                    let cn = res.custom_name.clone();
+                                    if res.apply_to_all {
+                                        apply_to_all_action = Some(res.action);
+                                    }
+                                    (a, cn)
+                                }
+                                Err(e) if e == "CONFLICT_CANCELLED" => {
+                                    cancelled = true;
+                                    skipped_count += 1;
+                                    completed += 1;
+                                    emit_clipboard_progress_item(
+                                        &app,
+                                        None,
+                                        completed,
+                                        total_items,
+                                        None,
+                                    );
+                                    continue;
+                                }
+                                Err(e) => return Err(e),
                             }
-                            Err(e) if e == "CONFLICT_CANCELLED" => {
+                        };
+                        match action {
+                            ConflictAction::Skip => Ok(None),
+                            ConflictAction::Replace => {
+                                // Guard: don't delete+copy if source and dest are the same location
+                                if source_location.raw() == dest_item_location.raw() {
+                                    Ok(Some(dest_raw))
+                                } else {
+                                    let _ = dest_provider.delete(&dest_item_location).await;
+                                    let op = if is_cut {
+                                        source_provider
+                                            .move_item(&source_location, &dest_item_location)
+                                            .await
+                                    } else {
+                                        source_provider
+                                            .copy(&source_location, &dest_item_location)
+                                            .await
+                                    };
+                                    op.map(|()| Some(dest_raw))
+                                }
+                            }
+                            // Merge not supported for remote providers — fall back to KeepBoth
+                            ConflictAction::Merge | ConflictAction::KeepBoth => {
+                                let stem = Path::new(&name)
+                                    .file_stem()
+                                    .and_then(|s| s.to_str())
+                                    .unwrap_or(&name);
+                                let ext = Path::new(&name).extension().and_then(|e| e.to_str());
+                                let mut resolved: Option<String> = None;
+                                for i in 2..1000usize {
+                                    let candidate_name = if let Some(e) = ext {
+                                        format!("{stem} ({i}).{e}")
+                                    } else {
+                                        format!("{stem} ({i})")
+                                    };
+                                    let candidate_raw =
+                                        join_dest_raw(&dest_scheme, &dest_dir_raw, &candidate_name);
+                                    let (_, candidate_loc) =
+                                        resolve_location(LI::Raw(candidate_raw.clone()))?;
+                                    if dest_provider
+                                        .get_file_metadata(&candidate_loc)
+                                        .await
+                                        .is_err()
+                                    {
+                                        let op = if is_cut {
+                                            source_provider
+                                                .move_item(&source_location, &candidate_loc)
+                                                .await
+                                        } else {
+                                            source_provider
+                                                .copy(&source_location, &candidate_loc)
+                                                .await
+                                        };
+                                        op?;
+                                        resolved = Some(candidate_raw);
+                                        break;
+                                    }
+                                }
+                                match resolved {
+                                Some(path) => Ok(Some(path)),
+                                None => Err(
+                                    "Unable to allocate unique destination name after 999 attempts"
+                                        .to_string(),
+                                ),
+                            }
+                            }
+                            ConflictAction::Rename => {
+                                let raw_name =
+                                    custom_name.ok_or("Rename requires a custom name")?;
+                                let safe_name = sanitize_conflict_name(&raw_name)?;
+                                let renamed_raw =
+                                    join_dest_raw(&dest_scheme, &dest_dir_raw, &safe_name);
+                                let (rp, renamed_location) =
+                                    resolve_location(LI::Raw(renamed_raw.clone()))?;
+                                // Check if the renamed target already exists
+                                if rp.get_file_metadata(&renamed_location).await.is_ok() {
+                                    return Err(format!(
+                                        "A file named '{safe_name}' already exists"
+                                    ));
+                                }
+                                let op = if is_cut {
+                                    source_provider
+                                        .move_item(&source_location, &renamed_location)
+                                        .await
+                                } else {
+                                    source_provider
+                                        .copy(&source_location, &renamed_location)
+                                        .await
+                                };
+                                op.map(|()| Some(renamed_raw))
+                            }
+                        }
+                    } else {
+                        let op = if is_cut {
+                            source_provider
+                                .move_item(&source_location, &dest_item_location)
+                                .await
+                        } else {
+                            source_provider
+                                .copy(&source_location, &dest_item_location)
+                                .await
+                        };
+                        op.map(|()| Some(dest_raw))
+                    }
+                }
+                ("file", "gdrive") => {
+                    let email = dest_location
+                        .authority()
+                        .ok_or_else(|| "Google Drive destination missing account".to_string())?;
+                    let folder_id = get_folder_id_by_path(email, dest_location.path()).await?;
+                    let local_path = PathBuf::from(source_location.to_path_string());
+                    if !local_path.exists() || !local_path.is_file() {
+                        Ok(None)
+                    } else {
+                        upload_file_to_gdrive(email, &local_path, &folder_id, &name).await?;
+                        let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &name);
+                        if is_cut {
+                            if let Err(e) = fs::remove_file(&local_path) {
+                                last_error =
+                                    Some(format!("Uploaded but failed to delete source: {e}"));
+                            }
+                        }
+                        Ok(Some(dest_raw))
+                    }
+                }
+                ("gdrive", "file") => {
+                    let Some(dest_dir) = dest_dir_path.as_ref() else {
+                        return Err("Local destination directory is required".to_string());
+                    };
+                    let email = source_location
+                        .authority()
+                        .ok_or_else(|| "Google Drive source missing account".to_string())?;
+                    let file_id = get_file_id_by_path(email, source_location.path()).await?;
+                    let temp_path = download_file_to_temp(email, &file_id, &name).await?;
+
+                    let candidate = dest_dir.join(&name);
+                    let op_result = if candidate.exists() {
+                        // Conflict
+                        let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
+                            (stored.clone(), None)
+                        } else {
+                            conflict_index += 1;
+                            let remaining = total_items.saturating_sub(completed + 1);
+                            let mut source_info = build_local_conflict_info(Path::new(&temp_path))?;
+                            // Override temp filename/path with real Google Drive name
+                            source_info.name = name.clone();
+                            source_info.path = source_location.raw().to_string();
+                            let dest_info = build_local_conflict_info(&candidate)?;
+                            match ask_user_about_conflict(
+                                &app,
+                                source_info,
+                                dest_info,
+                                conflict_index,
+                                remaining,
+                                operation_str,
+                            )
+                            .await
+                            {
+                                Ok(res) => {
+                                    let a = res.action.clone();
+                                    let cn = res.custom_name.clone();
+                                    if res.apply_to_all {
+                                        apply_to_all_action = Some(res.action);
+                                    }
+                                    (a, cn)
+                                }
+                                Err(e) if e == "CONFLICT_CANCELLED" => {
+                                    let _ = fs::remove_file(&temp_path);
+                                    cancelled = true;
+                                    skipped_count += 1;
+                                    completed += 1;
+                                    emit_clipboard_progress_item(
+                                        &app,
+                                        None,
+                                        completed,
+                                        total_items,
+                                        None,
+                                    );
+                                    continue;
+                                }
+                                Err(e) => {
+                                    let _ = fs::remove_file(&temp_path);
+                                    return Err(e);
+                                }
+                            }
+                        };
+                        match action {
+                            ConflictAction::Skip => {
                                 let _ = fs::remove_file(&temp_path);
-                                cancelled = true;
                                 skipped_count += 1;
                                 completed += 1;
-                                emit_clipboard_progress_item(&app, None, completed, total_items, None);
+                                emit_clipboard_progress_item(
+                                    &app,
+                                    None,
+                                    completed,
+                                    total_items,
+                                    None,
+                                );
                                 continue;
                             }
-                            Err(e) => {
-                                let _ = fs::remove_file(&temp_path);
-                                return Err(e);
-                            }
-                        }
-                    };
-                    match action {
-                        ConflictAction::Skip => {
-                            let _ = fs::remove_file(&temp_path);
-                            skipped_count += 1;
-                            completed += 1;
-                            emit_clipboard_progress_item(&app, None, completed, total_items, None);
-                            continue;
-                        }
-                        ConflictAction::Replace => {
-                            delete_file_or_directory(&candidate)
-                                .and_then(|_| crate::fs_utils::copy_file_or_directory(Path::new(&temp_path), &candidate))
-                                .map(|_| Some(candidate.to_string_lossy().to_string()))
-                        }
-                        // Merge not supported for cross-provider — use KeepBoth
-                        ConflictAction::KeepBoth | ConflictAction::Merge => {
-                            allocate_unique_path(dest_dir.as_path(), &name)
-                                .and_then(|dest_path| {
-                                    crate::fs_utils::copy_file_or_directory(Path::new(&temp_path), &dest_path)
-                                        .map(|_| Some(dest_path.to_string_lossy().to_string()))
+                            ConflictAction::Replace => delete_file_or_directory(&candidate)
+                                .and_then(|_| {
+                                    crate::fs_utils::copy_file_or_directory(
+                                        Path::new(&temp_path),
+                                        &candidate,
+                                    )
                                 })
-                        }
-                        ConflictAction::Rename => {
-                            custom_name.as_deref()
+                                .map(|_| Some(candidate.to_string_lossy().to_string())),
+                            // Merge not supported for cross-provider — use KeepBoth
+                            ConflictAction::KeepBoth | ConflictAction::Merge => {
+                                allocate_unique_path(dest_dir.as_path(), &name).and_then(
+                                    |dest_path| {
+                                        crate::fs_utils::copy_file_or_directory(
+                                            Path::new(&temp_path),
+                                            &dest_path,
+                                        )
+                                        .map(|_| Some(dest_path.to_string_lossy().to_string()))
+                                    },
+                                )
+                            }
+                            ConflictAction::Rename => custom_name
+                                .as_deref()
                                 .ok_or_else(|| "Rename requires a custom name".to_string())
                                 .and_then(|raw_name| sanitize_conflict_name(raw_name))
                                 .and_then(|safe_name| {
@@ -2810,428 +2966,481 @@ pub async fn paste_items_to_location(
                                     if dest_path.exists() {
                                         Err(format!("A file named '{safe_name}' already exists"))
                                     } else {
-                                        crate::fs_utils::copy_file_or_directory(Path::new(&temp_path), &dest_path)
-                                            .map(|_| Some(dest_path.to_string_lossy().to_string()))
+                                        crate::fs_utils::copy_file_or_directory(
+                                            Path::new(&temp_path),
+                                            &dest_path,
+                                        )
+                                        .map(|_| Some(dest_path.to_string_lossy().to_string()))
                                     }
-                                })
+                                }),
                         }
-                    }
-                } else {
-                    crate::fs_utils::copy_file_or_directory(Path::new(&temp_path), &candidate)
-                        .map(|_| Some(candidate.to_string_lossy().to_string()))
-                };
-
-                // Ensure temp file is removed after copy/move logic
-                let _ = fs::remove_file(&temp_path);
-
-                match op_result {
-                    Ok(Some(out)) => {
-                        if is_cut {
-                             if let Err(e) = source_provider.delete(&source_location).await {
-                                 last_error = Some(format!("Moved but failed to delete source: {e}"));
-                             }
-                        }
-                        Ok(Some(out))
-                    }
-                    Ok(None) => Ok(None),
-                    Err(e) => Err(e),
-                }
-            }
-            #[cfg(not(target_os = "windows"))]
-            ("smb", "file") => {
-                let Some(dest_dir) = dest_dir_path.as_ref() else {
-                    return Err("Local destination directory is required".to_string());
-                };
-
-                let from_authority = source_location
-                    .authority()
-                    .ok_or_else(|| "SMB source missing server".to_string())?;
-                let (hostname, share, from_rel) =
-                    crate::locations::smb::parse_smb_path(from_authority, source_location.path())?;
-
-                let candidate = dest_dir.join(&name);
-                let resolved_dest: Result<PathBuf, String> = if candidate.exists() {
-                    let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
-                        (stored.clone(), None)
                     } else {
-                        conflict_index += 1;
-                        let remaining = total_items.saturating_sub(completed + 1);
-                        // We don't have local source info for SMB, so build dest info only
-                        let dest_info = build_local_conflict_info(&candidate)?;
-                        let source_info = ConflictFileInfo {
-                            name: name.clone(),
-                            path: source_location.raw().to_string(),
-                            size: 0, // SMB file size not easily available here
-                            modified: String::new(),
-                            is_directory: false,
-                            extension: Path::new(&name).extension().and_then(|e| e.to_str()).map(|s| s.to_string()),
-                        };
-                        match ask_user_about_conflict(
-                            &app, source_info, dest_info,
-                            conflict_index, remaining, operation_str,
-                        ).await {
-                            Ok(res) => {
-                                let a = res.action.clone();
-                                let cn = res.custom_name.clone();
-                                if res.apply_to_all { apply_to_all_action = Some(res.action); }
-                                (a, cn)
+                        crate::fs_utils::copy_file_or_directory(Path::new(&temp_path), &candidate)
+                            .map(|_| Some(candidate.to_string_lossy().to_string()))
+                    };
+
+                    // Ensure temp file is removed after copy/move logic
+                    let _ = fs::remove_file(&temp_path);
+
+                    match op_result {
+                        Ok(Some(out)) => {
+                            if is_cut {
+                                if let Err(e) = source_provider.delete(&source_location).await {
+                                    last_error =
+                                        Some(format!("Moved but failed to delete source: {e}"));
+                                }
                             }
-                            Err(e) if e == "CONFLICT_CANCELLED" => {
-                                cancelled = true;
+                            Ok(Some(out))
+                        }
+                        Ok(None) => Ok(None),
+                        Err(e) => Err(e),
+                    }
+                }
+                #[cfg(not(target_os = "windows"))]
+                ("smb", "file") => {
+                    let Some(dest_dir) = dest_dir_path.as_ref() else {
+                        return Err("Local destination directory is required".to_string());
+                    };
+
+                    let from_authority = source_location
+                        .authority()
+                        .ok_or_else(|| "SMB source missing server".to_string())?;
+                    let (hostname, share, from_rel) = crate::locations::smb::parse_smb_path(
+                        from_authority,
+                        source_location.path(),
+                    )?;
+
+                    let candidate = dest_dir.join(&name);
+                    let resolved_dest: Result<PathBuf, String> = if candidate.exists() {
+                        let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
+                            (stored.clone(), None)
+                        } else {
+                            conflict_index += 1;
+                            let remaining = total_items.saturating_sub(completed + 1);
+                            // We don't have local source info for SMB, so build dest info only
+                            let dest_info = build_local_conflict_info(&candidate)?;
+                            let source_info = ConflictFileInfo {
+                                name: name.clone(),
+                                path: source_location.raw().to_string(),
+                                size: 0, // SMB file size not easily available here
+                                modified: String::new(),
+                                is_directory: false,
+                                extension: Path::new(&name)
+                                    .extension()
+                                    .and_then(|e| e.to_str())
+                                    .map(|s| s.to_string()),
+                            };
+                            match ask_user_about_conflict(
+                                &app,
+                                source_info,
+                                dest_info,
+                                conflict_index,
+                                remaining,
+                                operation_str,
+                            )
+                            .await
+                            {
+                                Ok(res) => {
+                                    let a = res.action.clone();
+                                    let cn = res.custom_name.clone();
+                                    if res.apply_to_all {
+                                        apply_to_all_action = Some(res.action);
+                                    }
+                                    (a, cn)
+                                }
+                                Err(e) if e == "CONFLICT_CANCELLED" => {
+                                    cancelled = true;
+                                    skipped_count += 1;
+                                    completed += 1;
+                                    emit_clipboard_progress_item(
+                                        &app,
+                                        None,
+                                        completed,
+                                        total_items,
+                                        None,
+                                    );
+                                    continue;
+                                }
+                                Err(e) => return Err(e),
+                            }
+                        };
+                        match action {
+                            ConflictAction::Skip => {
                                 skipped_count += 1;
                                 completed += 1;
-                                emit_clipboard_progress_item(&app, None, completed, total_items, None);
+                                emit_clipboard_progress_item(
+                                    &app,
+                                    None,
+                                    completed,
+                                    total_items,
+                                    None,
+                                );
                                 continue;
                             }
-                            Err(e) => return Err(e),
-                        }
-                    };
-                    match action {
-                        ConflictAction::Skip => { skipped_count += 1; completed += 1; emit_clipboard_progress_item(&app, None, completed, total_items, None); continue; }
-                        ConflictAction::Replace => {
-                            delete_file_or_directory(&candidate)?;
-                            Ok(candidate)
-                        }
-                        // Merge not supported for cross-provider — use KeepBoth
-                        ConflictAction::KeepBoth | ConflictAction::Merge => Ok(allocate_unique_path(dest_dir.as_path(), &name)?),
-                        ConflictAction::Rename => {
-                            let raw_name = custom_name.as_deref().ok_or("Rename requires a custom name")?;
-                            let safe_name = sanitize_conflict_name(raw_name)?;
-                            let dest_path = dest_dir.join(&safe_name);
-                            if dest_path.exists() {
-                                Err(format!("A file named '{safe_name}' already exists"))
-                            } else {
-                                Ok(dest_path)
+                            ConflictAction::Replace => {
+                                delete_file_or_directory(&candidate)?;
+                                Ok(candidate)
+                            }
+                            // Merge not supported for cross-provider — use KeepBoth
+                            ConflictAction::KeepBoth | ConflictAction::Merge => {
+                                Ok(allocate_unique_path(dest_dir.as_path(), &name)?)
+                            }
+                            ConflictAction::Rename => {
+                                let raw_name = custom_name
+                                    .as_deref()
+                                    .ok_or("Rename requires a custom name")?;
+                                let safe_name = sanitize_conflict_name(raw_name)?;
+                                let dest_path = dest_dir.join(&safe_name);
+                                if dest_path.exists() {
+                                    Err(format!("A file named '{safe_name}' already exists"))
+                                } else {
+                                    Ok(dest_path)
+                                }
                             }
                         }
-                    }
-                } else {
-                    Ok(candidate)
-                };
-                let dest_path = match resolved_dest {
-                    Ok(p) => p,
-                    Err(e) => {
-                        // Item-level error — record and continue
-                        Err(e)?
-                    }
-                };
-                let dest_path_string = dest_path.to_string_lossy().to_string();
-                let dest_path_clone = dest_path.clone();
-                let hostname_clone = hostname.clone();
-                let share_clone = share.clone();
-                let from_rel_clone = from_rel.clone();
+                    } else {
+                        Ok(candidate)
+                    };
+                    let dest_path = match resolved_dest {
+                        Ok(p) => p,
+                        Err(e) => {
+                            // Item-level error — record and continue
+                            Err(e)?
+                        }
+                    };
+                    let dest_path_string = dest_path.to_string_lossy().to_string();
+                    let dest_path_clone = dest_path.clone();
+                    let hostname_clone = hostname.clone();
+                    let share_clone = share.clone();
+                    let from_rel_clone = from_rel.clone();
 
-                tokio::task::spawn_blocking(move || -> Result<(), String> {
-                    crate::locations::smb::download_file_from_smb(
-                        &hostname_clone,
-                        &share_clone,
-                        &from_rel_clone,
-                        &dest_path_clone,
-                    )
-                })
-                .await
-                .map_err(|e| format!("Task failed: {e}"))??;
-
-                if is_cut {
-                    let _ = source_provider.delete(&source_location).await;
-                }
-                Ok(Some(dest_path_string))
-            }
-            #[cfg(not(target_os = "windows"))]
-            ("file", "smb") => {
-                let dest_authority = dest_location
-                    .authority()
-                    .ok_or_else(|| "SMB destination missing server".to_string())?;
-                let (hostname, share, dir_path) =
-                    crate::locations::smb::parse_smb_path(dest_authority, dest_location.path())?;
-
-                let local_path = PathBuf::from(source_location.to_path_string());
-                if !local_path.exists() || !local_path.is_file() {
-                    Ok(None)
-                } else {
-                    let name_clone = name.clone();
-                    let local_path_for_task = local_path.clone();
-
-                    let uploaded_name = tokio::task::spawn_blocking(move || -> Result<String, String> {
-                        crate::locations::smb::upload_file_to_smb(
-                            &local_path_for_task,
-                            &hostname,
-                            &share,
-                            &dir_path,
-                            &name_clone,
+                    tokio::task::spawn_blocking(move || -> Result<(), String> {
+                        crate::locations::smb::download_file_from_smb(
+                            &hostname_clone,
+                            &share_clone,
+                            &from_rel_clone,
+                            &dest_path_clone,
                         )
                     })
                     .await
                     .map_err(|e| format!("Task failed: {e}"))??;
 
+                    if is_cut {
+                        let _ = source_provider.delete(&source_location).await;
+                    }
+                    Ok(Some(dest_path_string))
+                }
+                #[cfg(not(target_os = "windows"))]
+                ("file", "smb") => {
+                    let dest_authority = dest_location
+                        .authority()
+                        .ok_or_else(|| "SMB destination missing server".to_string())?;
+                    let (hostname, share, dir_path) = crate::locations::smb::parse_smb_path(
+                        dest_authority,
+                        dest_location.path(),
+                    )?;
+
+                    let local_path = PathBuf::from(source_location.to_path_string());
+                    if !local_path.exists() || !local_path.is_file() {
+                        Ok(None)
+                    } else {
+                        let name_clone = name.clone();
+                        let local_path_for_task = local_path.clone();
+
+                        let uploaded_name =
+                            tokio::task::spawn_blocking(move || -> Result<String, String> {
+                                crate::locations::smb::upload_file_to_smb(
+                                    &local_path_for_task,
+                                    &hostname,
+                                    &share,
+                                    &dir_path,
+                                    &name_clone,
+                                )
+                            })
+                            .await
+                            .map_err(|e| format!("Task failed: {e}"))??;
+
+                        let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
+                        if is_cut {
+                            if let Err(e) = fs::remove_file(&local_path) {
+                                last_error =
+                                    Some(format!("Uploaded but failed to delete source: {e}"));
+                            }
+                        }
+                        Ok(Some(dest_raw))
+                    }
+                }
+                #[cfg(target_os = "windows")]
+                ("file", "smb") => Err("SMB support is not available on Windows".to_string()),
+                #[cfg(not(target_os = "windows"))]
+                ("gdrive", "smb") => {
+                    // Download from Google Drive to temp, then upload to SMB
+                    log::debug!("gdrive→smb: starting for name={}", name);
+                    let email = source_location
+                        .authority()
+                        .ok_or_else(|| "Google Drive source missing account".to_string())?;
+                    let file_id = get_file_id_by_path(email, source_location.path()).await?;
+                    let temp_path = download_file_to_temp(email, &file_id, &name).await?;
+                    log::debug!("gdrive→smb: downloaded to temp_path={}", temp_path);
+                    let local_path = PathBuf::from(&temp_path);
+
+                    let dest_authority = dest_location
+                        .authority()
+                        .ok_or_else(|| "SMB destination missing server".to_string())?;
+                    let (hostname, share, dir_path) = crate::locations::smb::parse_smb_path(
+                        dest_authority,
+                        dest_location.path(),
+                    )?;
+
+                    let name_clone = name.clone();
+                    let local_path_clone = local_path.clone();
+                    let uploaded_name =
+                        tokio::task::spawn_blocking(move || -> Result<String, String> {
+                            crate::locations::smb::upload_file_to_smb(
+                                &local_path_clone,
+                                &hostname,
+                                &share,
+                                &dir_path,
+                                &name_clone,
+                            )
+                        })
+                        .await
+                        .map_err(|e| format!("Task failed: {e}"));
+
+                    // Clean up temp file regardless of upload outcome
+                    let _ = fs::remove_file(&local_path);
+
+                    let uploaded_name = uploaded_name??;
                     let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
                     if is_cut {
-                        if let Err(e) = fs::remove_file(&local_path) {
-                            last_error = Some(format!("Uploaded but failed to delete source: {e}"));
-                        }
+                        let _ = source_provider.delete(&source_location).await;
                     }
                     Ok(Some(dest_raw))
                 }
-            }
-            #[cfg(target_os = "windows")]
-            ("file", "smb") => Err("SMB support is not available on Windows".to_string()),
-            #[cfg(not(target_os = "windows"))]
-            ("gdrive", "smb") => {
-                // Download from Google Drive to temp, then upload to SMB
-                log::debug!("gdrive→smb: starting for name={}", name);
-                let email = source_location
-                    .authority()
-                    .ok_or_else(|| "Google Drive source missing account".to_string())?;
-                let file_id = get_file_id_by_path(email, source_location.path()).await?;
-                let temp_path = download_file_to_temp(email, &file_id, &name).await?;
-                log::debug!("gdrive→smb: downloaded to temp_path={}", temp_path);
-                let local_path = PathBuf::from(&temp_path);
+                #[cfg(target_os = "windows")]
+                ("gdrive", "smb") => Err("SMB support is not available on Windows".to_string()),
+                // SFTP cross-provider paste
+                ("sftp", "file") => {
+                    let Some(dest_dir) = dest_dir_path.as_ref() else {
+                        return Err("Local destination directory is required".to_string());
+                    };
 
-                let dest_authority = dest_location
-                    .authority()
-                    .ok_or_else(|| "SMB destination missing server".to_string())?;
-                let (hostname, share, dir_path) =
-                    crate::locations::smb::parse_smb_path(dest_authority, dest_location.path())?;
+                    let (_, sftp_host, sftp_port, sftp_remote_path) =
+                        crate::locations::sftp::parse_sftp_url(source_location.raw())?;
 
-                let name_clone = name.clone();
-                let local_path_clone = local_path.clone();
-                let uploaded_name = tokio::task::spawn_blocking(move || -> Result<String, String> {
-                    crate::locations::smb::upload_file_to_smb(
-                        &local_path_clone,
-                        &hostname,
-                        &share,
-                        &dir_path,
-                        &name_clone,
+                    let dest_path = allocate_unique_path(dest_dir.as_path(), &name)?;
+                    let dest_path_string = dest_path.to_string_lossy().to_string();
+
+                    crate::locations::sftp::download_file_from_sftp(
+                        &sftp_host,
+                        sftp_port,
+                        &sftp_remote_path,
+                        &dest_path,
                     )
-                })
-                .await
-                .map_err(|e| format!("Task failed: {e}"));
+                    .await?;
 
-                // Clean up temp file regardless of upload outcome
-                let _ = fs::remove_file(&local_path);
-
-                let uploaded_name = uploaded_name??;
-                let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
-                if is_cut {
-                    let _ = source_provider.delete(&source_location).await;
+                    if is_cut {
+                        let _ = source_provider.delete(&source_location).await;
+                    }
+                    Ok(Some(dest_path_string))
                 }
-                Ok(Some(dest_raw))
-            }
-            #[cfg(target_os = "windows")]
-            ("gdrive", "smb") => Err("SMB support is not available on Windows".to_string()),
-            // SFTP cross-provider paste
-            ("sftp", "file") => {
-                let Some(dest_dir) = dest_dir_path.as_ref() else {
-                    return Err("Local destination directory is required".to_string());
-                };
+                ("file", "sftp") => {
+                    let (_, sftp_host, sftp_port, sftp_dir_path) =
+                        crate::locations::sftp::parse_sftp_url(dest_location.raw())?;
 
-                let (_, sftp_host, sftp_port, sftp_remote_path) =
-                    crate::locations::sftp::parse_sftp_url(source_location.raw())?;
+                    let local_path = PathBuf::from(source_location.to_path_string());
+                    if !local_path.exists() || !local_path.is_file() {
+                        Ok(None)
+                    } else {
+                        let uploaded_name = crate::locations::sftp::upload_file_to_sftp(
+                            &local_path,
+                            &sftp_host,
+                            sftp_port,
+                            &sftp_dir_path,
+                            &name,
+                        )
+                        .await?;
 
-                let dest_path = allocate_unique_path(dest_dir.as_path(), &name)?;
-                let dest_path_string = dest_path.to_string_lossy().to_string();
-
-                crate::locations::sftp::download_file_from_sftp(
-                    &sftp_host,
-                    sftp_port,
-                    &sftp_remote_path,
-                    &dest_path,
-                )
-                .await?;
-
-                if is_cut {
-                    let _ = source_provider.delete(&source_location).await;
+                        let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
+                        if is_cut {
+                            if let Err(e) = fs::remove_file(&local_path) {
+                                last_error =
+                                    Some(format!("Uploaded but failed to delete source: {e}"));
+                            }
+                        }
+                        Ok(Some(dest_raw))
+                    }
                 }
-                Ok(Some(dest_path_string))
-            }
-            ("file", "sftp") => {
-                let (_, sftp_host, sftp_port, sftp_dir_path) =
-                    crate::locations::sftp::parse_sftp_url(dest_location.raw())?;
+                ("gdrive", "sftp") => {
+                    let email = source_location
+                        .authority()
+                        .ok_or_else(|| "Google Drive source missing account".to_string())?;
+                    let file_id = get_file_id_by_path(email, source_location.path()).await?;
+                    let temp_path_str = download_file_to_temp(email, &file_id, &name).await?;
+                    let local_path = PathBuf::from(&temp_path_str);
 
-                let local_path = PathBuf::from(source_location.to_path_string());
-                if !local_path.exists() || !local_path.is_file() {
-                    Ok(None)
-                } else {
-                    let uploaded_name = crate::locations::sftp::upload_file_to_sftp(
+                    let (_, sftp_host, sftp_port, sftp_dir_path) =
+                        crate::locations::sftp::parse_sftp_url(dest_location.raw())?;
+
+                    let upload_result = crate::locations::sftp::upload_file_to_sftp(
                         &local_path,
                         &sftp_host,
                         sftp_port,
                         &sftp_dir_path,
                         &name,
                     )
-                    .await?;
+                    .await;
 
+                    let _ = fs::remove_file(&local_path);
+
+                    let uploaded_name = upload_result?;
                     let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
                     if is_cut {
-                        if let Err(e) = fs::remove_file(&local_path) {
-                            last_error = Some(format!("Uploaded but failed to delete source: {e}"));
-                        }
+                        let _ = source_provider.delete(&source_location).await;
                     }
                     Ok(Some(dest_raw))
                 }
-            }
-            ("gdrive", "sftp") => {
-                let email = source_location
-                    .authority()
-                    .ok_or_else(|| "Google Drive source missing account".to_string())?;
-                let file_id = get_file_id_by_path(email, source_location.path()).await?;
-                let temp_path_str = download_file_to_temp(email, &file_id, &name).await?;
-                let local_path = PathBuf::from(&temp_path_str);
+                ("sftp", "gdrive") => {
+                    let (_, sftp_host, sftp_port, sftp_remote_path) =
+                        crate::locations::sftp::parse_sftp_url(source_location.raw())?;
 
-                let (_, sftp_host, sftp_port, sftp_dir_path) =
-                    crate::locations::sftp::parse_sftp_url(dest_location.raw())?;
+                    let temp_dir = std::env::temp_dir().join("marlin-sftp-paste");
+                    tokio::fs::create_dir_all(&temp_dir)
+                        .await
+                        .map_err(|e| format!("Failed to create temp dir: {e}"))?;
+                    let temp_path = temp_dir.join(format!("{}_{}", uuid::Uuid::new_v4(), name));
 
-                let upload_result = crate::locations::sftp::upload_file_to_sftp(
-                    &local_path,
-                    &sftp_host,
-                    sftp_port,
-                    &sftp_dir_path,
-                    &name,
-                )
-                .await;
-
-                let _ = fs::remove_file(&local_path);
-
-                let uploaded_name = upload_result?;
-                let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
-                if is_cut {
-                    let _ = source_provider.delete(&source_location).await;
-                }
-                Ok(Some(dest_raw))
-            }
-            ("sftp", "gdrive") => {
-                let (_, sftp_host, sftp_port, sftp_remote_path) =
-                    crate::locations::sftp::parse_sftp_url(source_location.raw())?;
-
-                let temp_dir = std::env::temp_dir().join("marlin-sftp-paste");
-                tokio::fs::create_dir_all(&temp_dir)
-                    .await
-                    .map_err(|e| format!("Failed to create temp dir: {e}"))?;
-                let temp_path = temp_dir.join(format!("{}_{}", uuid::Uuid::new_v4(), name));
-
-                crate::locations::sftp::download_file_from_sftp(
-                    &sftp_host,
-                    sftp_port,
-                    &sftp_remote_path,
-                    &temp_path,
-                )
-                .await?;
-
-                let email = dest_location
-                    .authority()
-                    .ok_or_else(|| "Google Drive destination missing account".to_string())?;
-                let folder_id = get_folder_id_by_path(email, dest_location.path()).await?;
-                let upload_result = upload_file_to_gdrive(email, &temp_path, &folder_id, &name).await;
-
-                let _ = tokio::fs::remove_file(&temp_path).await;
-
-                upload_result?;
-                let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &name);
-                if is_cut {
-                    let _ = source_provider.delete(&source_location).await;
-                }
-                Ok(Some(dest_raw))
-            }
-            #[cfg(not(target_os = "windows"))]
-            ("smb", "sftp") => {
-                let from_authority = source_location
-                    .authority()
-                    .ok_or_else(|| "SMB source missing server".to_string())?;
-                let (smb_host, smb_share, smb_path) =
-                    crate::locations::smb::parse_smb_path(from_authority, source_location.path())?;
-
-                let temp_dir = std::env::temp_dir().join("marlin-cross-paste");
-                tokio::fs::create_dir_all(&temp_dir)
-                    .await
-                    .map_err(|e| format!("Failed to create temp dir: {e}"))?;
-                let temp_path = temp_dir.join(format!("{}_{}", uuid::Uuid::new_v4(), name));
-
-                let temp_path_clone = temp_path.clone();
-                let smb_host_clone = smb_host.clone();
-                let smb_share_clone = smb_share.clone();
-                let smb_path_clone = smb_path.clone();
-                tokio::task::spawn_blocking(move || {
-                    crate::locations::smb::download_file_from_smb(
-                        &smb_host_clone,
-                        &smb_share_clone,
-                        &smb_path_clone,
-                        &temp_path_clone,
+                    crate::locations::sftp::download_file_from_sftp(
+                        &sftp_host,
+                        sftp_port,
+                        &sftp_remote_path,
+                        &temp_path,
                     )
-                })
-                .await
-                .map_err(|e| format!("Task failed: {e}"))??;
+                    .await?;
 
-                let (_, sftp_host, sftp_port, sftp_dir_path) =
-                    crate::locations::sftp::parse_sftp_url(dest_location.raw())?;
+                    let email = dest_location
+                        .authority()
+                        .ok_or_else(|| "Google Drive destination missing account".to_string())?;
+                    let folder_id = get_folder_id_by_path(email, dest_location.path()).await?;
+                    let upload_result =
+                        upload_file_to_gdrive(email, &temp_path, &folder_id, &name).await;
 
-                let upload_result = crate::locations::sftp::upload_file_to_sftp(
-                    &temp_path,
-                    &sftp_host,
-                    sftp_port,
-                    &sftp_dir_path,
-                    &name,
-                )
-                .await;
+                    let _ = tokio::fs::remove_file(&temp_path).await;
 
-                let _ = tokio::fs::remove_file(&temp_path).await;
-
-                let uploaded_name = upload_result?;
-                let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
-                if is_cut {
-                    let _ = source_provider.delete(&source_location).await;
+                    upload_result?;
+                    let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &name);
+                    if is_cut {
+                        let _ = source_provider.delete(&source_location).await;
+                    }
+                    Ok(Some(dest_raw))
                 }
-                Ok(Some(dest_raw))
-            }
-            #[cfg(not(target_os = "windows"))]
-            ("sftp", "smb") => {
-                let (_, sftp_host, sftp_port, sftp_remote_path) =
-                    crate::locations::sftp::parse_sftp_url(source_location.raw())?;
+                #[cfg(not(target_os = "windows"))]
+                ("smb", "sftp") => {
+                    let from_authority = source_location
+                        .authority()
+                        .ok_or_else(|| "SMB source missing server".to_string())?;
+                    let (smb_host, smb_share, smb_path) = crate::locations::smb::parse_smb_path(
+                        from_authority,
+                        source_location.path(),
+                    )?;
 
-                let temp_dir = std::env::temp_dir().join("marlin-cross-paste");
-                tokio::fs::create_dir_all(&temp_dir)
+                    let temp_dir = std::env::temp_dir().join("marlin-cross-paste");
+                    tokio::fs::create_dir_all(&temp_dir)
+                        .await
+                        .map_err(|e| format!("Failed to create temp dir: {e}"))?;
+                    let temp_path = temp_dir.join(format!("{}_{}", uuid::Uuid::new_v4(), name));
+
+                    let temp_path_clone = temp_path.clone();
+                    let smb_host_clone = smb_host.clone();
+                    let smb_share_clone = smb_share.clone();
+                    let smb_path_clone = smb_path.clone();
+                    tokio::task::spawn_blocking(move || {
+                        crate::locations::smb::download_file_from_smb(
+                            &smb_host_clone,
+                            &smb_share_clone,
+                            &smb_path_clone,
+                            &temp_path_clone,
+                        )
+                    })
                     .await
-                    .map_err(|e| format!("Failed to create temp dir: {e}"))?;
-                let temp_path = temp_dir.join(format!("{}_{}", uuid::Uuid::new_v4(), name));
+                    .map_err(|e| format!("Task failed: {e}"))??;
 
-                crate::locations::sftp::download_file_from_sftp(
-                    &sftp_host,
-                    sftp_port,
-                    &sftp_remote_path,
-                    &temp_path,
-                )
-                .await?;
+                    let (_, sftp_host, sftp_port, sftp_dir_path) =
+                        crate::locations::sftp::parse_sftp_url(dest_location.raw())?;
 
-                let dest_authority = dest_location
-                    .authority()
-                    .ok_or_else(|| "SMB destination missing server".to_string())?;
-                let (smb_host, smb_share, smb_dir_path) =
-                    crate::locations::smb::parse_smb_path(dest_authority, dest_location.path())?;
-
-                let name_clone = name.clone();
-                let temp_path_clone = temp_path.clone();
-                let upload_result = tokio::task::spawn_blocking(move || {
-                    crate::locations::smb::upload_file_to_smb(
-                        &temp_path_clone,
-                        &smb_host,
-                        &smb_share,
-                        &smb_dir_path,
-                        &name_clone,
+                    let upload_result = crate::locations::sftp::upload_file_to_sftp(
+                        &temp_path,
+                        &sftp_host,
+                        sftp_port,
+                        &sftp_dir_path,
+                        &name,
                     )
-                })
-                .await
-                .map_err(|e| format!("Task failed: {e}"));
+                    .await;
 
-                let _ = tokio::fs::remove_file(&temp_path).await;
+                    let _ = tokio::fs::remove_file(&temp_path).await;
 
-                let uploaded_name = upload_result??;
-                let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
-                if is_cut {
-                    let _ = source_provider.delete(&source_location).await;
+                    let uploaded_name = upload_result?;
+                    let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
+                    if is_cut {
+                        let _ = source_provider.delete(&source_location).await;
+                    }
+                    Ok(Some(dest_raw))
                 }
-                Ok(Some(dest_raw))
-            }
-            _ => Err("Pasting across providers is not supported for these locations yet".to_string()),
-        };
+                #[cfg(not(target_os = "windows"))]
+                ("sftp", "smb") => {
+                    let (_, sftp_host, sftp_port, sftp_remote_path) =
+                        crate::locations::sftp::parse_sftp_url(source_location.raw())?;
+
+                    let temp_dir = std::env::temp_dir().join("marlin-cross-paste");
+                    tokio::fs::create_dir_all(&temp_dir)
+                        .await
+                        .map_err(|e| format!("Failed to create temp dir: {e}"))?;
+                    let temp_path = temp_dir.join(format!("{}_{}", uuid::Uuid::new_v4(), name));
+
+                    crate::locations::sftp::download_file_from_sftp(
+                        &sftp_host,
+                        sftp_port,
+                        &sftp_remote_path,
+                        &temp_path,
+                    )
+                    .await?;
+
+                    let dest_authority = dest_location
+                        .authority()
+                        .ok_or_else(|| "SMB destination missing server".to_string())?;
+                    let (smb_host, smb_share, smb_dir_path) =
+                        crate::locations::smb::parse_smb_path(
+                            dest_authority,
+                            dest_location.path(),
+                        )?;
+
+                    let name_clone = name.clone();
+                    let temp_path_clone = temp_path.clone();
+                    let upload_result = tokio::task::spawn_blocking(move || {
+                        crate::locations::smb::upload_file_to_smb(
+                            &temp_path_clone,
+                            &smb_host,
+                            &smb_share,
+                            &smb_dir_path,
+                            &name_clone,
+                        )
+                    })
+                    .await
+                    .map_err(|e| format!("Task failed: {e}"));
+
+                    let _ = tokio::fs::remove_file(&temp_path).await;
+
+                    let uploaded_name = upload_result??;
+                    let dest_raw = join_dest_raw(&dest_scheme, &dest_dir_raw, &uploaded_name);
+                    if is_cut {
+                        let _ = source_provider.delete(&source_location).await;
+                    }
+                    Ok(Some(dest_raw))
+                }
+                _ => Err(
+                    "Pasting across providers is not supported for these locations yet".to_string(),
+                ),
+            };
 
         match result {
             Ok(Some(p)) => pasted_paths.push(p),
@@ -3243,13 +3452,7 @@ pub async fn paste_items_to_location(
         }
 
         completed += 1;
-        emit_clipboard_progress_item(
-            &app,
-            None,
-            completed,
-            total_items,
-            last_error.clone(),
-        );
+        emit_clipboard_progress_item(&app, None, completed, total_items, last_error.clone());
     }
 
     // Clean up: hide the conflict dialog if it was shown
@@ -3344,7 +3547,9 @@ pub async fn clipboard_paste_image_to_location(
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("Screenshot");
-        let ext = std::path::Path::new(&base_name).extension().and_then(|e| e.to_str());
+        let ext = std::path::Path::new(&base_name)
+            .extension()
+            .and_then(|e| e.to_str());
         for i in 1..1000usize {
             if i == 1 {
                 candidate = base_name.clone();
@@ -3363,7 +3568,8 @@ pub async fn clipboard_paste_image_to_location(
         std::fs::create_dir_all(&temp_dir)
             .map_err(|e| format!("Failed to create temp directory: {e}"))?;
         let temp_path = temp_dir.join(format!("gdrive_upload_{}", uuid::Uuid::new_v4()));
-        std::fs::write(&temp_path, &image_bytes).map_err(|e| format!("Failed to write temp file: {e}"))?;
+        std::fs::write(&temp_path, &image_bytes)
+            .map_err(|e| format!("Failed to write temp file: {e}"))?;
 
         upload_file_to_gdrive(email, &temp_path, &folder_id, &candidate).await?;
 
@@ -3440,8 +3646,15 @@ pub async fn clipboard_paste_image_to_location(
 
             let (stem, ext) = {
                 let p = std::path::Path::new(&base_name);
-                let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("Screenshot").to_string();
-                let ext = p.extension().and_then(|e| e.to_str()).map(|s| s.to_string());
+                let stem = p
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("Screenshot")
+                    .to_string();
+                let ext = p
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(|s| s.to_string());
                 (stem, ext)
             };
 
@@ -3469,10 +3682,14 @@ pub async fn clipboard_paste_image_to_location(
                         let mut cursor = Cursor::new(&image_bytes[..]);
                         std::io::copy(&mut cursor, &mut dest_file)
                             .map_err(|e| format!("Failed to upload: {e}"))?;
-                        dest_file.flush().map_err(|e| format!("Failed to flush: {e}"))?;
+                        dest_file
+                            .flush()
+                            .map_err(|e| format!("Failed to flush: {e}"))?;
                         return Ok(candidate);
                     }
-                    Err(pavao::SmbError::Io(io)) if io.kind() == ErrorKind::AlreadyExists => continue,
+                    Err(pavao::SmbError::Io(io)) if io.kind() == ErrorKind::AlreadyExists => {
+                        continue
+                    }
                     Err(e) => return Err(format!("Failed to create destination: {e}")),
                 }
             }
@@ -3986,10 +4203,7 @@ fn numbered_name_variant(name: &str, index: usize) -> String {
         return name.to_string();
     }
     let path = Path::new(name);
-    let stem = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or(name);
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or(name);
     let ext = path.extension().and_then(|s| s.to_str());
     if let Some(ext) = ext {
         format!("{stem} ({index}).{ext}")
@@ -4034,13 +4248,8 @@ fn collect_local_zip_entries(
             });
 
         for entry in walker {
-            let entry = entry.map_err(|err| {
-                format!(
-                    "Failed to walk {}: {}",
-                    root.to_string_lossy(),
-                    err
-                )
-            })?;
+            let entry = entry
+                .map_err(|err| format!("Failed to walk {}: {}", root.to_string_lossy(), err))?;
 
             let file_type = entry.file_type();
             if file_type.is_symlink() {
@@ -4301,9 +4510,8 @@ fn write_zip_from_smb_entries(
     }
 
     for entry in entries {
-        let temp_path = crate::thumbnails::generators::smb::download_smb_file_sync(
-            &entry.source_path,
-        )?;
+        let temp_path =
+            crate::thumbnails::generators::smb::download_smb_file_sync(&entry.source_path)?;
 
         // Use a closure to ensure temp file cleanup on all paths
         let mut add_to_zip = || -> Result<(), String> {
@@ -4736,7 +4944,8 @@ pub async fn compress_to_zip(
                 }
                 sources.push(path);
             }
-            let strip_root = sources.len() == 1 && sources.first().map(|p| p.is_dir()).unwrap_or(false);
+            let strip_root =
+                sources.len() == 1 && sources.first().map(|p| p.is_dir()).unwrap_or(false);
 
             let final_path = allocate_unique_path(&dest_path, &sanitized_name)?;
             let archive_name = final_path
@@ -4753,47 +4962,48 @@ pub async fn compress_to_zip(
             let archive_name_for_task = archive_name.clone();
 
             let strip_root_for_task = strip_root;
-            let created_path = tauri::async_runtime::spawn_blocking(move || -> Result<PathBuf, String> {
-                let (entries, empty_dirs) =
-                    collect_local_zip_entries(&sources_for_task, strip_root_for_task)?;
-                if entries.is_empty() && empty_dirs.is_empty() && !strip_root_for_task {
-                    return Err("No files to compress".to_string());
-                }
-                let emit_progress = entries.len() >= COMPRESS_PROGRESS_ENTRY_THRESHOLD;
-                let write_result = write_zip_from_local_entries(
-                    &app_handle,
-                    &archive_name_for_task,
-                    &temp_path_for_task,
-                    &entries,
-                    &empty_dirs,
-                );
-                if let Err(err) = write_result {
-                    if emit_progress {
-                        emit_compress_progress_update(
-                            &app_handle,
-                            CompressProgressPayload {
-                                archive_name: archive_name_for_task.clone(),
-                                entry_name: None,
-                                completed: 0,
-                                total: entries.len(),
-                                finished: true,
-                                error: Some(err.clone()),
-                            },
-                        );
+            let created_path =
+                tauri::async_runtime::spawn_blocking(move || -> Result<PathBuf, String> {
+                    let (entries, empty_dirs) =
+                        collect_local_zip_entries(&sources_for_task, strip_root_for_task)?;
+                    if entries.is_empty() && empty_dirs.is_empty() && !strip_root_for_task {
+                        return Err("No files to compress".to_string());
                     }
-                    let _ = fs::remove_file(&temp_path_for_task);
-                    return Err(err);
-                }
+                    let emit_progress = entries.len() >= COMPRESS_PROGRESS_ENTRY_THRESHOLD;
+                    let write_result = write_zip_from_local_entries(
+                        &app_handle,
+                        &archive_name_for_task,
+                        &temp_path_for_task,
+                        &entries,
+                        &empty_dirs,
+                    );
+                    if let Err(err) = write_result {
+                        if emit_progress {
+                            emit_compress_progress_update(
+                                &app_handle,
+                                CompressProgressPayload {
+                                    archive_name: archive_name_for_task.clone(),
+                                    entry_name: None,
+                                    completed: 0,
+                                    total: entries.len(),
+                                    finished: true,
+                                    error: Some(err.clone()),
+                                },
+                            );
+                        }
+                        let _ = fs::remove_file(&temp_path_for_task);
+                        return Err(err);
+                    }
 
-                if let Err(err) = fs::rename(&temp_path_for_task, &final_path_for_task) {
-                    let _ = fs::remove_file(&temp_path_for_task);
-                    return Err(format!("Failed to finalize zip: {}", err));
-                }
+                    if let Err(err) = fs::rename(&temp_path_for_task, &final_path_for_task) {
+                        let _ = fs::remove_file(&temp_path_for_task);
+                        return Err(format!("Failed to finalize zip: {}", err));
+                    }
 
-                Ok(final_path_for_task)
-            })
-            .await
-            .map_err(|err| format!("Failed to join compression task: {}", err))??;
+                    Ok(final_path_for_task)
+                })
+                .await
+                .map_err(|err| format!("Failed to join compression task: {}", err))??;
 
             Ok(CompressToZipResponse {
                 path: created_path.to_string_lossy().to_string(),
@@ -4802,24 +5012,26 @@ pub async fn compress_to_zip(
         "smb" => {
             dest_provider.read_directory(&dest_location).await?;
             let strip_root = if source_locations.len() == 1 {
-                let metadata = dest_provider.get_file_metadata(&source_locations[0]).await?;
+                let metadata = dest_provider
+                    .get_file_metadata(&source_locations[0])
+                    .await?;
                 metadata.is_directory
             } else {
                 false
             };
-            let (entries, empty_dirs) = collect_remote_zip_entries(
-                &dest_provider,
-                source_locations.clone(),
-                strip_root,
-            )
-            .await?;
+            let (entries, empty_dirs) =
+                collect_remote_zip_entries(&dest_provider, source_locations.clone(), strip_root)
+                    .await?;
             if entries.is_empty() && empty_dirs.is_empty() && !strip_root {
                 return Err("No files to compress".to_string());
             }
 
             let existing = dest_provider.read_directory(&dest_location).await?;
-            let existing_names: HashSet<String> =
-                existing.entries.iter().map(|item| item.name.clone()).collect();
+            let existing_names: HashSet<String> = existing
+                .entries
+                .iter()
+                .map(|item| item.name.clone())
+                .collect();
             let mut final_name: Option<String> = None;
             for i in 1..1000usize {
                 let candidate = numbered_name_variant(&sanitized_name, i);
@@ -4886,9 +5098,9 @@ pub async fn compress_to_zip(
                 if !client::is_available() {
                     let status = client::initialize();
                     if status != SidecarStatus::Available {
-                        return Err(status.error_message().unwrap_or_else(|| {
-                            "SMB support is not available".to_string()
-                        }));
+                        return Err(status
+                            .error_message()
+                            .unwrap_or_else(|| "SMB support is not available".to_string()));
                     }
                 }
 
@@ -4926,17 +5138,16 @@ pub async fn compress_to_zip(
         "gdrive" => {
             dest_provider.read_directory(&dest_location).await?;
             let strip_root = if source_locations.len() == 1 {
-                let metadata = dest_provider.get_file_metadata(&source_locations[0]).await?;
+                let metadata = dest_provider
+                    .get_file_metadata(&source_locations[0])
+                    .await?;
                 metadata.is_directory
             } else {
                 false
             };
-            let (entries, empty_dirs) = collect_remote_zip_entries(
-                &dest_provider,
-                source_locations.clone(),
-                strip_root,
-            )
-            .await?;
+            let (entries, empty_dirs) =
+                collect_remote_zip_entries(&dest_provider, source_locations.clone(), strip_root)
+                    .await?;
             if entries.is_empty() && empty_dirs.is_empty() && !strip_root {
                 return Err("No files to compress".to_string());
             }
@@ -5635,10 +5846,7 @@ pub fn reveal_in_file_browser(path: String) -> Result<(), String> {
                 .parent()
                 .map(|parent| parent.to_string_lossy().to_string())
                 .ok_or_else(|| {
-                    format_error(
-                        error_codes::EOPEN,
-                        "Unable to resolve parent directory.",
-                    )
+                    format_error(error_codes::EOPEN, "Unable to resolve parent directory.")
                 })?
         };
 
@@ -6241,13 +6449,12 @@ pub fn open_smb_connect_window(
     }
 
     let url = tauri::WebviewUrl::App("index.html?view=smb-connect".into());
-    let builder = configure_modal_utility_window(&app, tauri::WebviewWindowBuilder::new(
+    let builder = configure_modal_utility_window(
         &app,
-        SMB_CONNECT_WINDOW_LABEL,
-        url,
-    ))
-        .title("Add Network Share")
-        .inner_size(460.0, 520.0);
+        tauri::WebviewWindowBuilder::new(&app, SMB_CONNECT_WINDOW_LABEL, url),
+    )
+    .title("Add Network Share")
+    .inner_size(460.0, 520.0);
 
     #[cfg(target_os = "macos")]
     let builder = builder
@@ -6300,13 +6507,12 @@ pub fn open_permissions_window(app: AppHandle) -> Result<(), String> {
     }
 
     let url = tauri::WebviewUrl::App("index.html?view=permissions".into());
-    let builder = configure_modal_utility_window(&app, tauri::WebviewWindowBuilder::new(
+    let builder = configure_modal_utility_window(
         &app,
-        PERMISSIONS_WINDOW_LABEL,
-        url,
-    ))
-        .title("Full Disk Access")
-        .inner_size(520.0, 560.0);
+        tauri::WebviewWindowBuilder::new(&app, PERMISSIONS_WINDOW_LABEL, url),
+    )
+    .title("Full Disk Access")
+    .inner_size(520.0, 560.0);
 
     #[cfg(target_os = "macos")]
     let builder = builder
@@ -6330,11 +6536,10 @@ pub fn open_preferences_window(app: AppHandle) -> Result<(), String> {
     }
 
     let url = tauri::WebviewUrl::App("index.html?view=preferences".into());
-    let builder = configure_modal_utility_window(&app, tauri::WebviewWindowBuilder::new(
+    let builder = configure_modal_utility_window(
         &app,
-        PREFERENCES_WINDOW_LABEL,
-        url,
-    ))
+        tauri::WebviewWindowBuilder::new(&app, PREFERENCES_WINDOW_LABEL, url),
+    )
     .title("Preferences")
     .inner_size(520.0, 560.0);
 
@@ -6609,9 +6814,12 @@ pub fn show_native_context_menu(
             .unwrap_or(false);
         let reveal_in_browser_item = if first_path_is_local {
             Some(
-                MenuItemBuilder::with_id("ctx:reveal_in_file_browser", get_reveal_in_browser_label())
-                    .build(&app)
-                    .map_err(|e| e.to_string())?,
+                MenuItemBuilder::with_id(
+                    "ctx:reveal_in_file_browser",
+                    get_reveal_in_browser_label(),
+                )
+                .build(&app)
+                .map_err(|e| e.to_string())?,
             )
         } else {
             None
@@ -7389,7 +7597,11 @@ pub async fn resolve_google_drive_url(url: String) -> Result<ResolveGoogleDriveU
 /// Download a Google Drive file to a temporary location and open it
 /// Returns the temporary file path
 #[command]
-pub async fn download_gdrive_file(email: String, file_id: String, file_name: String) -> Result<String, String> {
+pub async fn download_gdrive_file(
+    email: String,
+    file_id: String,
+    file_name: String,
+) -> Result<String, String> {
     download_file_to_temp(&email, &file_id, &file_name).await
 }
 
@@ -7563,7 +7775,9 @@ pub fn get_smb_status() -> SmbStatusResponse {
 pub fn get_smb_status() -> SmbStatusResponse {
     SmbStatusResponse {
         available: true,
-        reason: Some("Windows uses native UNC paths. Navigate to \\\\server\\share directly.".to_string()),
+        reason: Some(
+            "Windows uses native UNC paths. Navigate to \\\\server\\share directly.".to_string(),
+        ),
     }
 }
 
@@ -7606,7 +7820,14 @@ pub fn add_sftp_server(
     auth_method: String,
     key_path: Option<String>,
 ) -> Result<crate::locations::sftp::SftpServerInfo, String> {
-    crate::locations::sftp::add_sftp_server(hostname, port, username, password, auth_method, key_path)
+    crate::locations::sftp::add_sftp_server(
+        hostname,
+        port,
+        username,
+        password,
+        auth_method,
+        key_path,
+    )
 }
 
 /// Remove an SFTP server
@@ -7672,13 +7893,12 @@ pub fn open_sftp_connect_window(
     }
 
     let url = tauri::WebviewUrl::App("index.html?view=sftp-connect".into());
-    let builder = configure_modal_utility_window(&app, tauri::WebviewWindowBuilder::new(
+    let builder = configure_modal_utility_window(
         &app,
-        SFTP_CONNECT_WINDOW_LABEL,
-        url,
-    ))
-        .title("Add SFTP Server")
-        .inner_size(460.0, 600.0);
+        tauri::WebviewWindowBuilder::new(&app, SFTP_CONNECT_WINDOW_LABEL, url),
+    )
+    .title("Add SFTP Server")
+    .inner_size(460.0, 600.0);
 
     #[cfg(target_os = "macos")]
     let builder = builder
@@ -7735,11 +7955,10 @@ fn show_conflict_window_internal(app: &AppHandle) -> Result<(), String> {
     }
 
     let url = tauri::WebviewUrl::App("index.html?view=conflict".into());
-    let builder = configure_modal_utility_window(app, tauri::WebviewWindowBuilder::new(
+    let builder = configure_modal_utility_window(
         app,
-        CONFLICT_WINDOW_LABEL,
-        url,
-    ))
+        tauri::WebviewWindowBuilder::new(app, CONFLICT_WINDOW_LABEL, url),
+    )
     .title("File Conflict")
     .inner_size(520.0, 600.0);
 
@@ -7813,7 +8032,9 @@ pub fn conflict_window_unready() -> Result<(), String> {
 pub fn resolve_conflict(resolution: ConflictResolution) -> Result<(), String> {
     // Validate that the resolution matches the pending conflict
     {
-        let guard = CONFLICT_PENDING_PAYLOAD.lock().map_err(|e| format!("Lock failed: {e}"))?;
+        let guard = CONFLICT_PENDING_PAYLOAD
+            .lock()
+            .map_err(|e| format!("Lock failed: {e}"))?;
         if let Some(ref pending) = *guard {
             if pending.conflict_id != resolution.conflict_id {
                 return Err(format!(
@@ -7825,7 +8046,9 @@ pub fn resolve_conflict(resolution: ConflictResolution) -> Result<(), String> {
     }
 
     let sender = {
-        let mut guard = CONFLICT_SENDER.lock().map_err(|e| format!("Lock failed: {e}"))?;
+        let mut guard = CONFLICT_SENDER
+            .lock()
+            .map_err(|e| format!("Lock failed: {e}"))?;
         guard.take()
     };
     match sender {
@@ -7852,7 +8075,10 @@ fn build_local_conflict_info(path: &Path) -> Result<ConflictFileInfo, String> {
         .and_then(|n| n.to_str())
         .unwrap_or("")
         .to_string();
-    let extension = path.extension().and_then(|e| e.to_str()).map(|s| s.to_string());
+    let extension = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_string());
     Ok(ConflictFileInfo {
         name,
         path: path.to_string_lossy().to_string(),
@@ -7906,8 +8132,7 @@ async fn ask_user_about_conflict(
     CONFLICT_QUEUE.queue(app, payload);
 
     // Wait for user response (blocks until user picks an action or closes window)
-    rx.await
-        .map_err(|_| "CONFLICT_CANCELLED".to_string())
+    rx.await.map_err(|_| "CONFLICT_CANCELLED".to_string())
 }
 
 /// Hide the conflict dialog window.
@@ -7956,7 +8181,8 @@ async fn execute_local_conflict_action(
             let dest_path = dest_dir.join(name);
             // Guard: don't delete+copy if source IS the destination (same-folder paste)
             // Use canonicalize to handle case-insensitivity on macOS/Windows
-            let source_canon = fs::canonicalize(source_path).unwrap_or_else(|_| source_path.to_path_buf());
+            let source_canon =
+                fs::canonicalize(source_path).unwrap_or_else(|_| source_path.to_path_buf());
             let dest_canon = fs::canonicalize(&dest_path).unwrap_or_else(|_| dest_path.clone());
 
             if source_canon == dest_canon {
@@ -7967,9 +8193,13 @@ async fn execute_local_conflict_action(
             let dest_raw = dest_path.to_string_lossy().to_string();
             let (_, dest_item_location) = resolve_location(LI::Raw(dest_raw.clone()))?;
             if is_cut {
-                source_provider.move_item(source_location, &dest_item_location).await?;
+                source_provider
+                    .move_item(source_location, &dest_item_location)
+                    .await?;
             } else {
-                source_provider.copy(source_location, &dest_item_location).await?;
+                source_provider
+                    .copy(source_location, &dest_item_location)
+                    .await?;
             }
             Ok(Some(dest_raw))
         }
@@ -7983,9 +8213,13 @@ async fn execute_local_conflict_action(
             let dest_raw = dest_path.to_string_lossy().to_string();
             let (_, dest_item_location) = resolve_location(LI::Raw(dest_raw.clone()))?;
             if is_cut {
-                source_provider.move_item(source_location, &dest_item_location).await?;
+                source_provider
+                    .move_item(source_location, &dest_item_location)
+                    .await?;
             } else {
-                source_provider.copy(source_location, &dest_item_location).await?;
+                source_provider
+                    .copy(source_location, &dest_item_location)
+                    .await?;
             }
             Ok(Some(dest_raw))
         }
@@ -7993,7 +8227,8 @@ async fn execute_local_conflict_action(
         ConflictAction::Merge if source_path.is_dir() && dest_dir.join(name).is_dir() => {
             let dest_path = dest_dir.join(name);
             // Guard: don't merge a directory into itself
-            let source_canon = fs::canonicalize(source_path).unwrap_or_else(|_| source_path.to_path_buf());
+            let source_canon =
+                fs::canonicalize(source_path).unwrap_or_else(|_| source_path.to_path_buf());
             let dest_canon = fs::canonicalize(&dest_path).unwrap_or_else(|_| dest_path.clone());
             if source_canon == dest_canon {
                 return Ok(Some(dest_path.to_string_lossy().to_string()));
@@ -8011,9 +8246,13 @@ async fn execute_local_conflict_action(
             let dest_raw = dest_path.to_string_lossy().to_string();
             let (_, dest_item_location) = resolve_location(LI::Raw(dest_raw.clone()))?;
             if is_cut {
-                source_provider.move_item(source_location, &dest_item_location).await?;
+                source_provider
+                    .move_item(source_location, &dest_item_location)
+                    .await?;
             } else {
-                source_provider.copy(source_location, &dest_item_location).await?;
+                source_provider
+                    .copy(source_location, &dest_item_location)
+                    .await?;
             }
             Ok(Some(dest_raw))
         }
@@ -8024,14 +8263,17 @@ fn copy_symlink(src: &Path, dst: &Path) -> Result<(), String> {
     let target = fs::read_link(src).map_err(|e| format!("Failed to read link: {e}"))?;
     #[cfg(unix)]
     {
-        std::os::unix::fs::symlink(target, dst).map_err(|e| format!("Failed to create symlink: {e}"))
+        std::os::unix::fs::symlink(target, dst)
+            .map_err(|e| format!("Failed to create symlink: {e}"))
     }
     #[cfg(windows)]
     {
         if src.is_dir() {
-            std::os::windows::fs::symlink_dir(target, dst).map_err(|e| format!("Failed to create symlink: {e}"))
+            std::os::windows::fs::symlink_dir(target, dst)
+                .map_err(|e| format!("Failed to create symlink: {e}"))
         } else {
-            std::os::windows::fs::symlink_file(target, dst).map_err(|e| format!("Failed to create symlink: {e}"))
+            std::os::windows::fs::symlink_file(target, dst)
+                .map_err(|e| format!("Failed to create symlink: {e}"))
         }
     }
     #[cfg(not(any(unix, windows)))]
@@ -8050,31 +8292,30 @@ fn merge_local_directory(source: &Path, dest: &Path, is_cut: bool) -> Result<(),
     for entry in entries {
         let entry = entry.map_err(|e| format!("Failed to read entry: {e}"))?;
         let entry_path = entry.path();
-        let entry_name = entry
-            .file_name()
-            .to_string_lossy()
-            .to_string();
+        let entry_name = entry.file_name().to_string_lossy().to_string();
         let dest_path = dest.join(&entry_name);
 
-        let file_type = entry.file_type().map_err(|e| format!("Failed to get file type: {e}"))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|e| format!("Failed to get file type: {e}"))?;
 
         if file_type.is_symlink() {
-             if dest_path.exists() {
-                 let unique = allocate_unique_path(dest, &entry_name)?;
-                 if is_cut {
+            if dest_path.exists() {
+                let unique = allocate_unique_path(dest, &entry_name)?;
+                if is_cut {
                     fs::rename(&entry_path, &unique)
                         .map_err(|e| format!("Failed to move {}: {e}", entry_path.display()))?;
-                 } else {
+                } else {
                     copy_symlink(&entry_path, &unique)?;
-                 }
-             } else {
-                 if is_cut {
+                }
+            } else {
+                if is_cut {
                     fs::rename(&entry_path, &dest_path)
                         .map_err(|e| format!("Failed to move {}: {e}", entry_path.display()))?;
-                 } else {
+                } else {
                     copy_symlink(&entry_path, &dest_path)?;
-                 }
-             }
+                }
+            }
         } else if file_type.is_dir() {
             if dest_path.exists() && dest_path.is_dir() {
                 // Recursively merge subdirectories
@@ -8190,7 +8431,9 @@ pub async fn show_file_properties(paths: Vec<String>) -> Result<(), String> {
         use std::os::windows::ffi::OsStrExt;
         use windows::core::PCWSTR;
         use windows::Win32::Foundation::HWND;
-        use windows::Win32::UI::Shell::{ShellExecuteExW, SHELLEXECUTEINFOW, SEE_MASK_INVOKEIDLIST};
+        use windows::Win32::UI::Shell::{
+            ShellExecuteExW, SEE_MASK_INVOKEIDLIST, SHELLEXECUTEINFOW,
+        };
 
         for path in paths.iter().take(MAX_PROPERTIES_WINDOWS) {
             let expanded = expand_path(path)?;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1365,6 +1365,8 @@ pub struct DropOperationInfo {
     pub reason: Option<String>,
 }
 
+const SAME_LOCATION_DROP_REASON: &str = "NO_OP_SAME_LOCATION";
+
 fn is_remote_fs(fs_type: &str) -> bool {
     let lower = fs_type.to_lowercase();
     lower.contains("smb")
@@ -1391,6 +1393,9 @@ pub async fn resolve_drop_operation(
     let dest_canon = dest_path.canonicalize().ok();
 
     if let Some(ref d_canon) = dest_canon {
+        let mut checked_sources = 0usize;
+        let mut all_sources_already_in_destination = true;
+
         for source in &sources {
             let source_path_buf = match fs_utils::expand_path(source) {
                 Ok(p) => p,
@@ -1398,14 +1403,26 @@ pub async fn resolve_drop_operation(
             };
 
             if let Ok(s_canon) = source_path_buf.canonicalize() {
+                checked_sources += 1;
+
                 // Cannot drop item onto itself
                 if s_canon == *d_canon {
                     return Ok(DropOperationInfo {
                         operation: "none".to_string(),
                         is_remote: false,
                         valid: false,
-                        reason: Some("Cannot drop item onto itself".to_string()),
+                        reason: Some(SAME_LOCATION_DROP_REASON.to_string()),
                     });
+                }
+
+                let source_parent_matches_destination = s_canon
+                    .parent()
+                    .and_then(|parent| parent.canonicalize().ok())
+                    .as_ref()
+                    == Some(d_canon);
+
+                if !source_parent_matches_destination {
+                    all_sources_already_in_destination = false;
                 }
 
                 // Cannot drop folder into itself or descendant
@@ -1418,6 +1435,15 @@ pub async fn resolve_drop_operation(
                     });
                 }
             }
+        }
+
+        if checked_sources > 0 && all_sources_already_in_destination {
+            return Ok(DropOperationInfo {
+                operation: "none".to_string(),
+                is_remote: false,
+                valid: false,
+                reason: Some(SAME_LOCATION_DROP_REASON.to_string()),
+            });
         }
     }
 
@@ -2571,7 +2597,14 @@ pub async fn paste_items_to_location(
                     let candidate = dest_dir.join(&name);
                     let source_path = PathBuf::from(source_location.to_path_string());
 
-                    if candidate.exists() {
+                    if candidate
+                        .canonicalize()
+                        .ok()
+                        .zip(source_path.canonicalize().ok())
+                        .is_some_and(|(candidate, source)| candidate == source)
+                    {
+                        Ok(None)
+                    } else if candidate.exists() {
                         // Conflict detected — resolve it
                         let (action, custom_name) = if let Some(ref stored) = apply_to_all_action {
                             (stored.clone(), None)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2597,7 +2597,18 @@ pub async fn paste_items_to_location(
                     let candidate = dest_dir.join(&name);
                     let source_path = PathBuf::from(source_location.to_path_string());
 
-                    if candidate
+                    if source_path
+                        .canonicalize()
+                        .ok()
+                        .and_then(|path| path.parent().map(Path::to_path_buf))
+                        .and_then(|parent| parent.canonicalize().ok())
+                        .as_ref()
+                        == dest_dir.canonicalize().ok().as_ref()
+                    {
+                        completed += 1;
+                        emit_clipboard_progress_item(&app, None, completed, total_items, None);
+                        continue;
+                    } else if candidate
                         .canonicalize()
                         .ok()
                         .zip(source_path.canonicalize().ok())

--- a/src-tauri/src/fs_utils.rs
+++ b/src-tauri/src/fs_utils.rs
@@ -124,18 +124,21 @@ pub struct MetadataBatch {
 /// These are typically system-generated files that users don't want to see.
 /// Note: .DS_Store is already covered by the dotfile check.
 const HIDDEN_SYSTEM_FILES: &[&str] = &[
-    "Thumbs.db",      // Windows thumbnail cache
-    "desktop.ini",    // Windows folder settings
-    "ehthumbs.db",    // Windows Media Center thumbnails
-    "ehthumbs_vista.db", // Vista Media Center thumbnails
-    "$RECYCLE.BIN",   // Windows recycle bin folder
+    "Thumbs.db",                 // Windows thumbnail cache
+    "desktop.ini",               // Windows folder settings
+    "ehthumbs.db",               // Windows Media Center thumbnails
+    "ehthumbs_vista.db",         // Vista Media Center thumbnails
+    "$RECYCLE.BIN",              // Windows recycle bin folder
     "System Volume Information", // Windows system folder
 ];
 
 /// Check if a file should be considered hidden.
 /// Returns true for dotfiles and known system files.
 pub fn is_hidden_file(name: &str) -> bool {
-    name.starts_with('.') || HIDDEN_SYSTEM_FILES.iter().any(|&f| name.eq_ignore_ascii_case(f))
+    name.starts_with('.')
+        || HIDDEN_SYSTEM_FILES
+            .iter()
+            .any(|&f| name.eq_ignore_ascii_case(f))
 }
 
 /// Build a skeleton FileItem from a DirEntry without any stat() calls.
@@ -161,15 +164,15 @@ fn build_file_item_skeleton(entry: &std::fs::DirEntry) -> Option<FileItem> {
     Some(FileItem {
         name: file_name,
         path: path.to_string_lossy().to_string(),
-        size: 0, // Filled in by metadata update
+        size: 0,              // Filled in by metadata update
         modified: Utc::now(), // Placeholder, filled in by metadata update
         is_directory,
         is_hidden,
         is_symlink: file_type.is_symlink(),
         is_git_repo: false, // Filled in by metadata update
         extension,
-        child_count: None, // Filled in by metadata update
-        image_width: None, // Filled in by metadata update
+        child_count: None,  // Filled in by metadata update
+        image_width: None,  // Filled in by metadata update
         image_height: None, // Filled in by metadata update
         remote_id: None,
         thumbnail_url: None,
@@ -200,7 +203,9 @@ fn build_file_metadata(path: &Path) -> Option<FileMetadataUpdate> {
 
     // Compute shallow child count for directories
     let child_count = if is_directory {
-        fs::read_dir(path).ok().map(|entries| entries.count() as u64)
+        fs::read_dir(path)
+            .ok()
+            .map(|entries| entries.count() as u64)
     } else {
         None
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,6 +170,7 @@ pub fn run() {
             commands::update_selection_menu_state,
             commands::calculate_folder_size,
             commands::cancel_folder_size_calculation,
+            commands::authorize_folder_access,
             commands::render_svg_to_png,
             commands::read_preferences,
             commands::write_preferences,

--- a/src-tauri/src/locations/archive/mod.rs
+++ b/src-tauri/src/locations/archive/mod.rs
@@ -6,11 +6,11 @@ use url::Url;
 use urlencoding::encode;
 
 use crate::fs_utils::{expand_path, is_hidden_file, FileItem};
+use crate::locations::gdrive::provider::{download_file_to_temp, get_file_id_by_path};
+use crate::locations::LocationInput;
 use crate::locations::{
     Location, LocationCapabilities, LocationProvider, LocationSummary, ProviderDirectoryEntries,
 };
-use crate::locations::gdrive::provider::{download_file_to_temp, get_file_id_by_path};
-use crate::locations::LocationInput;
 
 #[cfg(not(target_os = "windows"))]
 use crate::thumbnails::generators::smb::download_smb_file_sync;
@@ -125,8 +125,7 @@ async fn resolve_non_archive_source(src: &str) -> Result<PathBuf, String> {
             {
                 let smb_path = location.raw().to_string();
                 let temp_path = spawn_blocking(move || {
-                    download_smb_file_sync(&smb_path)
-                        .map(|p| p.to_string_lossy().to_string())
+                    download_smb_file_sync(&smb_path).map(|p| p.to_string_lossy().to_string())
                 })
                 .await
                 .map_err(|e| format!("Task join error: {e}"))??;
@@ -243,18 +242,20 @@ impl LocationProvider for ArchiveProvider {
         LocationCapabilities::new("archive", "Archive", true, false)
     }
 
-    async fn read_directory(&self, location: &Location) -> Result<ProviderDirectoryEntries, String> {
+    async fn read_directory(
+        &self,
+        location: &Location,
+    ) -> Result<ProviderDirectoryEntries, String> {
         let archive_location = parse_archive_uri(location.raw())?;
         let src = archive_location.src.clone();
         let archive_path = resolve_archive_source(&src).await?;
         let internal_path = archive_location.path.clone();
         let internal_path_for_task = internal_path.clone();
 
-        let entries = spawn_blocking(move || {
-            reader::list_directory(&archive_path, &internal_path_for_task)
-        })
-            .await
-            .map_err(|e| format!("Task join error: {e}"))??;
+        let entries =
+            spawn_blocking(move || reader::list_directory(&archive_path, &internal_path_for_task))
+                .await
+                .map_err(|e| format!("Task join error: {e}"))??;
 
         let file_items = entries
             .into_iter()
@@ -285,8 +286,8 @@ impl LocationProvider for ArchiveProvider {
         let metadata = spawn_blocking(move || {
             reader::get_entry_metadata(&archive_path, &internal_path_for_task)
         })
-            .await
-            .map_err(|e| format!("Task join error: {e}"))??;
+        .await
+        .map_err(|e| format!("Task join error: {e}"))??;
 
         let mut file_item = entry_to_file_item(metadata, &src);
         if internal_path == "/" {

--- a/src-tauri/src/locations/archive/reader.rs
+++ b/src-tauri/src/locations/archive/reader.rs
@@ -10,10 +10,10 @@ use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
 use tar::Archive as TarArchive;
 use unrar::Archive as RarArchive;
+use uuid::Uuid;
 use xz2::read::XzDecoder;
 use zip::ZipArchive;
 use zstd::stream::read::Decoder as ZstdDecoder;
-use uuid::Uuid;
 
 const MAX_ENTRIES: usize = 100_000;
 const MAX_TOTAL_SIZE: u64 = 2 * 1024 * 1024 * 1024;
@@ -156,7 +156,9 @@ fn normalize_entry_path(raw: &str) -> Result<String, String> {
     if value.len() >= 2 {
         let bytes = value.as_bytes();
         if bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
-            return Err(format!("Refusing Windows drive path in archive entry: {raw}"));
+            return Err(format!(
+                "Refusing Windows drive path in archive entry: {raw}"
+            ));
         }
     }
 
@@ -311,7 +313,10 @@ fn build_entries(parent_path: &str, map: HashMap<String, EntryInfo>) -> Vec<Arch
     entries
 }
 
-pub fn list_directory(archive_path: &Path, internal_path: &str) -> Result<Vec<ArchiveEntry>, String> {
+pub fn list_directory(
+    archive_path: &Path,
+    internal_path: &str,
+) -> Result<Vec<ArchiveEntry>, String> {
     // Check cache first - avoids O(n) scan for repeated listings
     // Uses Arc for cheap cloning of the entry list
     if let Some(cached_entries) = get_cached_entries(archive_path) {
@@ -332,8 +337,8 @@ pub fn list_directory(archive_path: &Path, internal_path: &str) -> Result<Vec<Ar
         ArchiveFormat::Zip => {
             let file = File::open(archive_path)
                 .map_err(|e| format!("Failed to open archive {}: {e}", archive_path.display()))?;
-            let mut archive = ZipArchive::new(file)
-                .map_err(|e| format!("Failed to read zip archive: {e}"))?;
+            let mut archive =
+                ZipArchive::new(file).map_err(|e| format!("Failed to read zip archive: {e}"))?;
 
             if archive.len() > MAX_ENTRIES {
                 return Err("Archive contains too many entries to list".to_string());
@@ -398,18 +403,14 @@ pub fn list_directory(archive_path: &Path, internal_path: &str) -> Result<Vec<Ar
                 .map_err(|e| format!("Failed to open RAR archive: {e}"))?;
 
             for header_result in archive {
-                let header = header_result
-                    .map_err(|e| format!("Failed to read RAR entry: {e}"))?;
+                let header = header_result.map_err(|e| format!("Failed to read RAR entry: {e}"))?;
 
                 seen_entries += 1;
                 if seen_entries > MAX_ENTRIES {
                     return Err("Archive contains too many entries to list".to_string());
                 }
 
-                let entry_name = header
-                    .filename
-                    .to_string_lossy()
-                    .to_string();
+                let entry_name = header.filename.to_string_lossy().to_string();
                 let normalized = match normalize_entry_path(&entry_name) {
                     Ok(value) => value,
                     Err(_) => continue,
@@ -505,7 +506,14 @@ pub fn list_directory(archive_path: &Path, internal_path: &str) -> Result<Vec<Ar
                     modified,
                 });
 
-                push_entry(&mut children, parent_rel, &normalized, is_dir, size, modified);
+                push_entry(
+                    &mut children,
+                    parent_rel,
+                    &normalized,
+                    is_dir,
+                    size,
+                    modified,
+                );
             }
         }
     }
@@ -582,8 +590,8 @@ pub fn get_entry_metadata(
         ArchiveFormat::Zip => {
             let file = File::open(archive_path)
                 .map_err(|e| format!("Failed to open archive {}: {e}", archive_path.display()))?;
-            let mut archive = ZipArchive::new(file)
-                .map_err(|e| format!("Failed to read zip archive: {e}"))?;
+            let mut archive =
+                ZipArchive::new(file).map_err(|e| format!("Failed to read zip archive: {e}"))?;
 
             for i in 0..archive.len() {
                 let file = archive
@@ -621,8 +629,7 @@ pub fn get_entry_metadata(
                 .map_err(|e| format!("Failed to open RAR archive: {e}"))?;
 
             for header_result in archive {
-                let header = header_result
-                    .map_err(|e| format!("Failed to read RAR entry: {e}"))?;
+                let header = header_result.map_err(|e| format!("Failed to read RAR entry: {e}"))?;
                 let entry_name = header.filename.to_string_lossy().to_string();
                 let normalized_entry = match normalize_entry_path(&entry_name) {
                     Ok(value) => value,
@@ -727,8 +734,8 @@ pub fn extract_entry_to_dir(
         ArchiveFormat::Zip => {
             let file = File::open(archive_path)
                 .map_err(|e| format!("Failed to open archive {}: {e}", archive_path.display()))?;
-            let mut archive = ZipArchive::new(file)
-                .map_err(|e| format!("Failed to read zip archive: {e}"))?;
+            let mut archive =
+                ZipArchive::new(file).map_err(|e| format!("Failed to read zip archive: {e}"))?;
 
             // Find the entry by normalized path (handles ./foo.txt, backslashes, etc.)
             let mut found_index: Option<usize> = None;
@@ -842,7 +849,8 @@ pub fn extract_entry_to_dir(
                 .map_err(|e| format!("Failed to read tar entries: {e}"))?;
 
             for entry_result in entries {
-                let mut entry = entry_result.map_err(|e| format!("Failed to read tar entry: {e}"))?;
+                let mut entry =
+                    entry_result.map_err(|e| format!("Failed to read tar entry: {e}"))?;
                 let path = entry
                     .path()
                     .map_err(|e| format!("Failed to read tar entry path: {e}"))?;
@@ -913,12 +921,10 @@ pub fn extract_entry_to_path(
     let parent = output_path
         .parent()
         .ok_or_else(|| "Invalid output path".to_string())?;
-    fs::create_dir_all(parent)
-        .map_err(|e| format!("Failed to create output directory: {e}"))?;
+    fs::create_dir_all(parent).map_err(|e| format!("Failed to create output directory: {e}"))?;
 
     let temp_dir = parent.join(format!(".__marlin_extract_{}", Uuid::new_v4()));
-    fs::create_dir_all(&temp_dir)
-        .map_err(|e| format!("Failed to create temp directory: {e}"))?;
+    fs::create_dir_all(&temp_dir).map_err(|e| format!("Failed to create temp directory: {e}"))?;
 
     let extracted = extract_entry_to_dir(archive_path, internal_path, &temp_dir)?;
 
@@ -933,10 +939,7 @@ pub fn extract_entry_to_path(
     Ok(output_path.to_path_buf())
 }
 
-fn create_tar_reader(
-    format: ArchiveFormat,
-    archive_path: &Path,
-) -> Result<Box<dyn Read>, String> {
+fn create_tar_reader(format: ArchiveFormat, archive_path: &Path) -> Result<Box<dyn Read>, String> {
     let file = File::open(archive_path)
         .map_err(|e| format!("Failed to open archive {}: {e}", archive_path.display()))?;
     let reader: Box<dyn Read> = match format {
@@ -945,8 +948,7 @@ fn create_tar_reader(
         ArchiveFormat::TarBz2 => Box::new(BzDecoder::new(file)),
         ArchiveFormat::TarXz => Box::new(XzDecoder::new(file)),
         ArchiveFormat::TarZst => Box::new(
-            ZstdDecoder::new(file)
-                .map_err(|e| format!("Failed to read zst archive: {e}"))?,
+            ZstdDecoder::new(file).map_err(|e| format!("Failed to read zst archive: {e}"))?,
         ),
         ArchiveFormat::Zip | ArchiveFormat::Rar => {
             return Err("Invalid tar archive format".to_string())

--- a/src-tauri/src/locations/file.rs
+++ b/src-tauri/src/locations/file.rs
@@ -68,7 +68,10 @@ impl LocationProvider for FileSystemProvider {
             .with_supports_watching(true)
     }
 
-    async fn read_directory(&self, location: &Location) -> Result<ProviderDirectoryEntries, String> {
+    async fn read_directory(
+        &self,
+        location: &Location,
+    ) -> Result<ProviderDirectoryEntries, String> {
         let (path, summary) = self.resolve_path(location)?;
 
         spawn_blocking(move || {

--- a/src-tauri/src/locations/gdrive/provider.rs
+++ b/src-tauri/src/locations/gdrive/provider.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use google_drive3::api::File as DriveFile;
-use google_drive3::DriveHub;
 use google_drive3::hyper_rustls::HttpsConnector;
+use google_drive3::DriveHub;
 use hyper_util::client::legacy::connect::HttpConnector;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
@@ -21,7 +21,7 @@ const VIRTUAL_SHARED_DRIVES: &str = "Shared drives";
 const VIRTUAL_SHARED: &str = "Shared with me";
 const VIRTUAL_STARRED: &str = "Starred";
 const VIRTUAL_RECENT: &str = "Recent";
-const VIRTUAL_BY_ID: &str = "id";  // For direct ID-based navigation
+const VIRTUAL_BY_ID: &str = "id"; // For direct ID-based navigation
 
 /// Cache entry with TTL
 #[allow(dead_code)]
@@ -81,8 +81,9 @@ impl GoogleDriveProvider {
             .enable_http2()
             .build();
 
-        let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-            .build(connector);
+        let client =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                .build(connector);
 
         // Create an authenticator that uses our stored token
         let auth = yup_oauth2::AccessTokenAuthenticator::builder(access_token)
@@ -223,7 +224,12 @@ impl GoogleDriveProvider {
 
     /// Convert a Drive file to FileItem
     /// For folders in "Shared with me", use ID-based paths for reliable navigation
-    fn drive_file_to_file_item(&self, file: &DriveFile, email: &str, parent_path: &str) -> FileItem {
+    fn drive_file_to_file_item(
+        &self,
+        file: &DriveFile,
+        email: &str,
+        parent_path: &str,
+    ) -> FileItem {
         let name = file.name.clone().unwrap_or_else(|| "Untitled".to_string());
         let is_folder = file.mime_type.as_deref() == Some("application/vnd.google-apps.folder");
         let file_id = file.id.clone().unwrap_or_default();
@@ -241,15 +247,13 @@ impl GoogleDriveProvider {
             format!("gdrive://{}{}/{}", email, parent_path, &name)
         };
 
-        let modified = file
-            .modified_time
-            .unwrap_or_else(Utc::now);
+        let modified = file.modified_time.unwrap_or_else(Utc::now);
 
-        let size = file.size
-            .unwrap_or(0) as u64;
+        let size = file.size.unwrap_or(0) as u64;
 
         let extension = if !is_folder {
-            name.rsplit('.').next()
+            name.rsplit('.')
+                .next()
                 .filter(|ext| ext.len() < 10 && !ext.contains(' '))
                 .map(|s| s.to_lowercase())
         } else {
@@ -264,12 +268,7 @@ impl GoogleDriveProvider {
         let (image_width, image_height) = file
             .image_media_metadata
             .as_ref()
-            .map(|meta| {
-                (
-                    meta.width.map(|w| w as u32),
-                    meta.height.map(|h| h as u32),
-                )
-            })
+            .map(|meta| (meta.width.map(|w| w as u32), meta.height.map(|h| h as u32)))
             .unwrap_or((None, None));
 
         FileItem {
@@ -285,14 +284,22 @@ impl GoogleDriveProvider {
             child_count: None,
             image_width,
             image_height,
-            remote_id: if file_id.is_empty() { None } else { Some(file_id) },
+            remote_id: if file_id.is_empty() {
+                None
+            } else {
+                Some(file_id)
+            },
             thumbnail_url,
             download_url,
         }
     }
 
     /// List files in My Drive root
-    async fn list_my_drive_root(&self, hub: &DriveHubType, email: &str) -> Result<Vec<FileItem>, String> {
+    async fn list_my_drive_root(
+        &self,
+        hub: &DriveHubType,
+        email: &str,
+    ) -> Result<Vec<FileItem>, String> {
         log::debug!("Listing My Drive root for {}", email);
         let result = hub
             .files()
@@ -327,7 +334,11 @@ impl GoogleDriveProvider {
         parent_path: &str,
     ) -> Result<Vec<FileItem>, String> {
         let query = format!("'{}' in parents and trashed = false", folder_id);
-        log::debug!("list_folder_by_id: folder_id={}, query={}", folder_id, query);
+        log::debug!(
+            "list_folder_by_id: folder_id={}, query={}",
+            folder_id,
+            query
+        );
 
         let result = hub
             .files()
@@ -352,7 +363,11 @@ impl GoogleDriveProvider {
     }
 
     /// List shared files
-    async fn list_shared_with_me(&self, hub: &DriveHubType, email: &str) -> Result<Vec<FileItem>, String> {
+    async fn list_shared_with_me(
+        &self,
+        hub: &DriveHubType,
+        email: &str,
+    ) -> Result<Vec<FileItem>, String> {
         let result = hub
             .files()
             .list()
@@ -419,7 +434,11 @@ impl GoogleDriveProvider {
     }
 
     /// List all shared drives the user has access to
-    async fn list_shared_drives(&self, hub: &DriveHubType, email: &str) -> Result<Vec<FileItem>, String> {
+    async fn list_shared_drives(
+        &self,
+        hub: &DriveHubType,
+        email: &str,
+    ) -> Result<Vec<FileItem>, String> {
         let result = hub
             .drives()
             .list()
@@ -436,7 +455,10 @@ impl GoogleDriveProvider {
         Ok(drives
             .iter()
             .map(|d| {
-                let name = d.name.clone().unwrap_or_else(|| "Unnamed Drive".to_string());
+                let name = d
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| "Unnamed Drive".to_string());
                 let drive_id = d.id.clone().unwrap_or_default();
                 FileItem {
                     name: name.clone(),
@@ -460,7 +482,11 @@ impl GoogleDriveProvider {
     }
 
     /// Find a shared drive by name
-    async fn find_shared_drive_by_name(&self, hub: &DriveHubType, name: &str) -> Result<Option<String>, String> {
+    async fn find_shared_drive_by_name(
+        &self,
+        hub: &DriveHubType,
+        name: &str,
+    ) -> Result<Option<String>, String> {
         let result = hub
             .drives()
             .list()
@@ -565,7 +591,8 @@ impl GoogleDriveProvider {
         hub: &DriveHubType,
         path_parts: &[&str],
     ) -> Result<Option<String>, String> {
-        self.find_file_by_path_from_parent(hub, "root", path_parts).await
+        self.find_file_by_path_from_parent(hub, "root", path_parts)
+            .await
     }
 
     /// Find a file by path starting from a specific parent
@@ -636,7 +663,7 @@ impl GoogleDriveProvider {
             .files()
             .list()
             .q(&query)
-            .page_size(10)  // Get more results to see what's available
+            .page_size(10) // Get more results to see what's available
             .add_scope(google_drive3::api::Scope::Full)
             .param("fields", "files(id,name)")
             .doit()
@@ -644,12 +671,19 @@ impl GoogleDriveProvider {
             .map_err(|e| format!("Failed to search for shared file: {}", e))?;
 
         let files = result.1.files.unwrap_or_default();
-        log::debug!("  -> found {} shared items with name '{}'", files.len(), first_name);
+        log::debug!(
+            "  -> found {} shared items with name '{}'",
+            files.len(),
+            first_name
+        );
 
         let shared_item = match files.first() {
             Some(f) => f.id.clone().unwrap_or_default(),
             None => {
-                log::debug!("  -> no shared item found with name '{}', returning None", first_name);
+                log::debug!(
+                    "  -> no shared item found with name '{}', returning None",
+                    first_name
+                );
                 return Ok(None);
             }
         };
@@ -664,21 +698,21 @@ impl GoogleDriveProvider {
 
         // Otherwise, navigate into children from the shared item
         log::debug!("  -> navigating into children: {:?}", &path_parts[1..]);
-        self.find_file_by_path_from_parent(hub, &shared_item, &path_parts[1..]).await
+        self.find_file_by_path_from_parent(hub, &shared_item, &path_parts[1..])
+            .await
     }
 
     /// Get file metadata by ID
-    async fn get_file_by_id(
-        &self,
-        hub: &DriveHubType,
-        file_id: &str,
-    ) -> Result<DriveFile, String> {
+    async fn get_file_by_id(&self, hub: &DriveHubType, file_id: &str) -> Result<DriveFile, String> {
         let result = hub
             .files()
             .get(file_id)
             .supports_all_drives(true)
             .add_scope(google_drive3::api::Scope::Full)
-            .param("fields", "id,name,mimeType,size,modifiedTime,parents,driveId")
+            .param(
+                "fields",
+                "id,name,mimeType,size,modifiedTime,parents,driveId",
+            )
             .doit()
             .await
             .map_err(|e| format!("Failed to get file: {}", e))?;
@@ -694,8 +728,13 @@ impl GoogleDriveProvider {
         file: &DriveFile,
         email: &str,
     ) -> Result<String, String> {
-        log::debug!("build_file_path: file={:?}, id={:?}, parents={:?}, driveId={:?}",
-            file.name, file.id, file.parents, file.drive_id);
+        log::debug!(
+            "build_file_path: file={:?}, id={:?}, parents={:?}, driveId={:?}",
+            file.name,
+            file.id,
+            file.parents,
+            file.drive_id
+        );
 
         let file_id = file.id.clone().unwrap_or_default();
         let mut path_parts = vec![file.name.clone().unwrap_or_else(|| "Untitled".to_string())];
@@ -732,8 +771,12 @@ impl GoogleDriveProvider {
             }
 
             let parent = self.get_file_by_id(hub, parent_id).await?;
-            log::debug!("  -> parent name={:?}, id={:?}, parents={:?}",
-                parent.name, parent.id, parent.parents);
+            log::debug!(
+                "  -> parent name={:?}, id={:?}, parents={:?}",
+                parent.name,
+                parent.id,
+                parent.parents
+            );
 
             // Check if this parent is a Shared Drive root (has no parents but has drive_id)
             let parent_parents = parent.parents.clone().unwrap_or_default();
@@ -742,7 +785,12 @@ impl GoogleDriveProvider {
                 break;
             }
 
-            path_parts.push(parent.name.clone().unwrap_or_else(|| "Untitled".to_string()));
+            path_parts.push(
+                parent
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| "Untitled".to_string()),
+            );
             current_parents = parent_parents;
         }
 
@@ -783,7 +831,10 @@ impl LocationProvider for GoogleDriveProvider {
         }
     }
 
-    async fn read_directory(&self, location: &Location) -> Result<ProviderDirectoryEntries, String> {
+    async fn read_directory(
+        &self,
+        location: &Location,
+    ) -> Result<ProviderDirectoryEntries, String> {
         let email = self.get_account_email(location)?;
         let path = location.path();
 
@@ -810,10 +861,13 @@ impl LocationProvider for GoogleDriveProvider {
                     self.list_my_drive_root(&hub, &email).await?
                 } else {
                     // Find folder ID by path
-                    let folder_id = self.find_file_by_path(&hub, &subpath).await?
+                    let folder_id = self
+                        .find_file_by_path(&hub, &subpath)
+                        .await?
                         .ok_or_else(|| format!("Folder not found: {}", subpath.join("/")))?;
 
-                    self.list_folder_by_id(&hub, &folder_id, &email, path).await?
+                    self.list_folder_by_id(&hub, &folder_id, &email, path)
+                        .await?
                 }
             }
             VIRTUAL_SHARED => {
@@ -824,11 +878,14 @@ impl LocationProvider for GoogleDriveProvider {
                     // Navigate into a shared folder
                     // For shared items, use special lookup that finds shared items first
                     log::debug!("  -> finding shared file by path: {:?}", subpath);
-                    let folder_id = self.find_shared_file_by_path(&hub, &subpath).await?
+                    let folder_id = self
+                        .find_shared_file_by_path(&hub, &subpath)
+                        .await?
                         .ok_or_else(|| format!("Folder not found: {}", subpath.join("/")))?;
 
                     log::debug!("  -> found folder_id: {}", folder_id);
-                    self.list_folder_by_id(&hub, &folder_id, &email, path).await?
+                    self.list_folder_by_id(&hub, &folder_id, &email, path)
+                        .await?
                 }
             }
             VIRTUAL_STARRED => self.list_starred(&hub, &email).await?,
@@ -843,18 +900,29 @@ impl LocationProvider for GoogleDriveProvider {
                     log::debug!("  -> listing shared drive: {}", drive_name);
 
                     // Find the drive ID by name
-                    let drive_id = self.find_shared_drive_by_name(&hub, drive_name).await?
+                    let drive_id = self
+                        .find_shared_drive_by_name(&hub, drive_name)
+                        .await?
                         .ok_or_else(|| format!("Shared drive not found: {}", drive_name))?;
 
                     if subpath.len() == 1 {
                         // List root of shared drive
-                        self.list_shared_drive_root(&hub, &drive_id, &email, path).await?
+                        self.list_shared_drive_root(&hub, &drive_id, &email, path)
+                            .await?
                     } else {
                         // Navigate within shared drive
                         let inner_path = &subpath[1..];
-                        let folder_id = self.find_file_in_shared_drive(&hub, &drive_id, inner_path).await?
-                            .ok_or_else(|| format!("Folder not found in shared drive: {}", inner_path.join("/")))?;
-                        self.list_folder_by_id(&hub, &folder_id, &email, path).await?
+                        let folder_id = self
+                            .find_file_in_shared_drive(&hub, &drive_id, inner_path)
+                            .await?
+                            .ok_or_else(|| {
+                                format!(
+                                    "Folder not found in shared drive: {}",
+                                    inner_path.join("/")
+                                )
+                            })?;
+                        self.list_folder_by_id(&hub, &folder_id, &email, path)
+                            .await?
                     }
                 }
             }
@@ -935,11 +1003,20 @@ impl LocationProvider for GoogleDriveProvider {
         let hub = self.create_hub(&email).await?;
 
         // Find the file by path
-        let file_id = self.find_file_by_path(&hub, &subpath).await?
+        let file_id = self
+            .find_file_by_path(&hub, &subpath)
+            .await?
             .ok_or_else(|| format!("File not found: {}", path))?;
 
         let file = self.get_file_by_id(&hub, &file_id).await?;
-        let parent_path = path.rsplit('/').skip(1).collect::<Vec<_>>().into_iter().rev().collect::<Vec<_>>().join("/");
+        let parent_path = path
+            .rsplit('/')
+            .skip(1)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join("/");
 
         Ok(self.drive_file_to_file_item(&file, &email, &format!("/{}", parent_path)))
     }
@@ -965,7 +1042,8 @@ impl LocationProvider for GoogleDriveProvider {
         let parent_id = if parent_path.is_empty() {
             "root".to_string()
         } else {
-            self.find_file_by_path(&hub, parent_path).await?
+            self.find_file_by_path(&hub, parent_path)
+                .await?
                 .ok_or_else(|| "Parent folder not found".to_string())?
         };
 
@@ -1002,7 +1080,9 @@ impl LocationProvider for GoogleDriveProvider {
 
         let hub = self.create_hub(&email).await?;
 
-        let file_id = self.find_file_by_path(&hub, &subpath).await?
+        let file_id = self
+            .find_file_by_path(&hub, &subpath)
+            .await?
             .ok_or_else(|| "File not found".to_string())?;
 
         // Move to trash instead of permanent delete
@@ -1041,10 +1121,13 @@ impl LocationProvider for GoogleDriveProvider {
 
         let hub = self.create_hub(&from_email).await?;
 
-        let file_id = self.find_file_by_path(&hub, &from_subpath).await?
+        let file_id = self
+            .find_file_by_path(&hub, &from_subpath)
+            .await?
             .ok_or_else(|| "Source file not found".to_string())?;
 
-        let new_name = to_subpath.last()
+        let new_name = to_subpath
+            .last()
             .ok_or_else(|| "Invalid destination path".to_string())?;
 
         let update = DriveFile {
@@ -1086,7 +1169,9 @@ impl LocationProvider for GoogleDriveProvider {
 
         let hub = self.create_hub(&from_email).await?;
 
-        let file_id = self.find_file_by_path(&hub, &from_subpath).await?
+        let file_id = self
+            .find_file_by_path(&hub, &from_subpath)
+            .await?
             .ok_or_else(|| "Source file not found".to_string())?;
 
         // Find destination parent
@@ -1094,11 +1179,13 @@ impl LocationProvider for GoogleDriveProvider {
         let dest_parent_id = if dest_parent_path.is_empty() {
             "root".to_string()
         } else {
-            self.find_file_by_path(&hub, dest_parent_path).await?
+            self.find_file_by_path(&hub, dest_parent_path)
+                .await?
                 .ok_or_else(|| "Destination folder not found".to_string())?
         };
 
-        let new_name = to_subpath.last()
+        let new_name = to_subpath
+            .last()
             .ok_or_else(|| "Invalid destination path".to_string())?;
 
         let copy_request = DriveFile {
@@ -1141,7 +1228,9 @@ impl LocationProvider for GoogleDriveProvider {
 
         let hub = self.create_hub(&from_email).await?;
 
-        let file_id = self.find_file_by_path(&hub, &from_subpath).await?
+        let file_id = self
+            .find_file_by_path(&hub, &from_subpath)
+            .await?
             .ok_or_else(|| "Source file not found".to_string())?;
 
         // Get current parents
@@ -1153,11 +1242,13 @@ impl LocationProvider for GoogleDriveProvider {
         let dest_parent_id = if dest_parent_path.is_empty() {
             "root".to_string()
         } else {
-            self.find_file_by_path(&hub, dest_parent_path).await?
+            self.find_file_by_path(&hub, dest_parent_path)
+                .await?
                 .ok_or_else(|| "Destination folder not found".to_string())?
         };
 
-        let new_name = to_subpath.last()
+        let new_name = to_subpath
+            .last()
             .ok_or_else(|| "Invalid destination path".to_string())?;
 
         // Update with new parent and possibly new name
@@ -1206,7 +1297,9 @@ pub async fn resolve_file_id_to_path(file_id: &str) -> Result<(String, String), 
             Ok(file) => {
                 log::info!("    Found file: {:?}", file.name);
                 // Found it! Build the path
-                let path = provider.build_file_path(&hub, &file, &account.email).await?;
+                let path = provider
+                    .build_file_path(&hub, &file, &account.email)
+                    .await?;
                 log::info!("    Built path: {}", path);
                 return Ok((account.email.clone(), path));
             }
@@ -1228,7 +1321,11 @@ pub async fn resolve_folder_id(
     accounts: &[String],
     folder_id: &str,
 ) -> Result<(String, String, String), String> {
-    log::info!("resolve_folder_id: folder_id={}, accounts={:?}", folder_id, accounts);
+    log::info!(
+        "resolve_folder_id: folder_id={}, accounts={:?}",
+        folder_id,
+        accounts
+    );
 
     if accounts.is_empty() {
         return Err("No accounts provided".to_string());
@@ -1242,13 +1339,21 @@ pub async fn resolve_folder_id(
                 return Ok((email.clone(), path, name));
             }
             Err(e) => {
-                log::info!("  Account {} cannot access folder {}: {}", email, folder_id, e);
+                log::info!(
+                    "  Account {} cannot access folder {}: {}",
+                    email,
+                    folder_id,
+                    e
+                );
                 continue;
             }
         }
     }
 
-    Err(format!("No connected account has access to folder {}", folder_id))
+    Err(format!(
+        "No connected account has access to folder {}",
+        folder_id
+    ))
 }
 
 async fn try_resolve_folder_id(email: &str, folder_id: &str) -> Result<(String, String), String> {
@@ -1391,7 +1496,12 @@ async fn build_shared_drive_path(
             if parents.is_empty() {
                 // Reached root
                 path_parts.reverse();
-                return Ok(format!("/{}/{}/{}", VIRTUAL_SHARED_DRIVES, drive_name, path_parts.join("/")));
+                return Ok(format!(
+                    "/{}/{}/{}",
+                    VIRTUAL_SHARED_DRIVES,
+                    drive_name,
+                    path_parts.join("/")
+                ));
             }
 
             if let Some(parent_id) = parents.first().and_then(|p| p.as_str()) {
@@ -1399,7 +1509,12 @@ async fn build_shared_drive_path(
                 if parent_id == drive_id {
                     path_parts.push(name.to_string());
                     path_parts.reverse();
-                    return Ok(format!("/{}/{}/{}", VIRTUAL_SHARED_DRIVES, drive_name, path_parts.join("/")));
+                    return Ok(format!(
+                        "/{}/{}/{}",
+                        VIRTUAL_SHARED_DRIVES,
+                        drive_name,
+                        path_parts.join("/")
+                    ));
                 }
                 path_parts.push(name.to_string());
                 current_id = parent_id.to_string();
@@ -1409,17 +1524,19 @@ async fn build_shared_drive_path(
         } else {
             // No parents - reached some root
             path_parts.reverse();
-            return Ok(format!("/{}/{}/{}", VIRTUAL_SHARED_DRIVES, drive_name, path_parts.join("/")));
+            return Ok(format!(
+                "/{}/{}/{}",
+                VIRTUAL_SHARED_DRIVES,
+                drive_name,
+                path_parts.join("/")
+            ));
         }
     }
 
     Err("Path too deep".to_string())
 }
 
-async fn build_path_from_parents(
-    folder_id: &str,
-    access_token: &str,
-) -> Result<String, String> {
+async fn build_path_from_parents(folder_id: &str, access_token: &str) -> Result<String, String> {
     let client = reqwest::Client::new();
     let mut path_parts: Vec<String> = Vec::new();
     let mut current_id = folder_id.to_string();
@@ -1504,19 +1621,25 @@ pub async fn fetch_url_with_auth(email: &str, url: &str) -> Result<String, Strin
         return Err(format!("Fetch failed with status {}", status));
     }
 
-    let content_type = response.headers()
+    let content_type = response
+        .headers()
         .get(reqwest::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("image/jpeg")
         .to_string();
 
-    let bytes = response.bytes()
+    let bytes = response
+        .bytes()
         .await
         .map_err(|e| format!("Failed to read response: {}", e))?;
 
     let base64_data = base64::engine::general_purpose::STANDARD.encode(&bytes);
 
-    log::info!("fetch_url_with_auth: got {} bytes, content_type={}", bytes.len(), content_type);
+    log::info!(
+        "fetch_url_with_auth: got {} bytes, content_type={}",
+        bytes.len(),
+        content_type
+    );
 
     Ok(format!("data:{};base64,{}", content_type, base64_data))
 }
@@ -1539,11 +1662,20 @@ fn sanitize_filename(name: &str) -> String {
 
 /// Download a Google Drive file to a temporary location and return the path
 /// This is used for opening files that need to be downloaded first
-pub async fn download_file_to_temp(email: &str, file_id: &str, file_name: &str) -> Result<String, String> {
+pub async fn download_file_to_temp(
+    email: &str,
+    file_id: &str,
+    file_name: &str,
+) -> Result<String, String> {
     use std::io::Write;
     use std::time::{Duration, SystemTime};
 
-    log::info!("download_file_to_temp: email={}, file_id={}, name={}", email, file_id, file_name);
+    log::info!(
+        "download_file_to_temp: email={}, file_id={}, name={}",
+        email,
+        file_id,
+        file_name
+    );
 
     // Create temp directory if it doesn't exist
     let temp_dir = std::env::temp_dir().join("marlin-gdrive-cache");
@@ -1595,10 +1727,14 @@ pub async fn download_file_to_temp(email: &str, file_id: &str, file_name: &str) 
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         log::error!("Download failed with status {}: {}", status, body);
-        return Err(format!("Download failed (status {}). Check logs for details.", status));
+        return Err(format!(
+            "Download failed (status {}). Check logs for details.",
+            status
+        ));
     }
 
-    let bytes = response.bytes()
+    let bytes = response
+        .bytes()
         .await
         .map_err(|e| format!("Failed to read file content: {}", e))?;
 
@@ -1623,14 +1759,17 @@ pub async fn upload_file_to_gdrive(
 ) -> Result<String, String> {
     log::info!(
         "upload_file_to_gdrive: email={}, local_path={:?}, parent={}, name={}",
-        email, local_path, parent_folder_id, file_name
+        email,
+        local_path,
+        parent_folder_id,
+        file_name
     );
 
     let access_token = ensure_valid_token(email).await?;
 
     // Read the file content
-    let file_content = std::fs::read(local_path)
-        .map_err(|e| format!("Failed to read file: {}", e))?;
+    let file_content =
+        std::fs::read(local_path).map_err(|e| format!("Failed to read file: {}", e))?;
 
     // Determine MIME type based on extension
     let mime_type = mime_guess::from_path(local_path)
@@ -1675,13 +1814,19 @@ pub async fn upload_file_to_gdrive(
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         log::error!("Upload failed with status {}: {}", status, body);
-        return Err(format!("Upload failed (status {}). Check logs for details.", status));
+        return Err(format!(
+            "Upload failed (status {}). Check logs for details.",
+            status
+        ));
     }
 
-    let result: serde_json::Value = response.json().await
+    let result: serde_json::Value = response
+        .json()
+        .await
         .map_err(|e| format!("Failed to parse upload response: {}", e))?;
 
-    let file_id = result["id"].as_str()
+    let file_id = result["id"]
+        .as_str()
         .ok_or_else(|| "No file ID in upload response".to_string())?
         .to_string();
 
@@ -1698,7 +1843,9 @@ pub async fn create_gdrive_folder(
 ) -> Result<String, String> {
     log::info!(
         "create_gdrive_folder: email={}, parent={}, name={}",
-        email, parent_folder_id, folder_name
+        email,
+        parent_folder_id,
+        folder_name
     );
 
     let access_token = ensure_valid_token(email).await?;
@@ -1723,13 +1870,19 @@ pub async fn create_gdrive_folder(
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         log::error!("Create folder failed with status {}: {}", status, body);
-        return Err(format!("Create folder failed (status {}). Check logs for details.", status));
+        return Err(format!(
+            "Create folder failed (status {}). Check logs for details.",
+            status
+        ));
     }
 
-    let result: serde_json::Value = response.json().await
+    let result: serde_json::Value = response
+        .json()
+        .await
         .map_err(|e| format!("Failed to parse create folder response: {}", e))?;
 
-    let folder_id = result["id"].as_str()
+    let folder_id = result["id"]
+        .as_str()
         .ok_or_else(|| "No folder ID in response".to_string())?
         .to_string();
 
@@ -1743,23 +1896,29 @@ pub async fn upload_directory_to_gdrive(
     local_dir: &std::path::Path,
     parent_folder_id: &str,
 ) -> Result<String, String> {
-    let dir_name = local_dir.file_name()
+    let dir_name = local_dir
+        .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| "Invalid directory name".to_string())?;
 
-    log::info!("upload_directory_to_gdrive: dir={:?}, parent={}", local_dir, parent_folder_id);
+    log::info!(
+        "upload_directory_to_gdrive: dir={:?}, parent={}",
+        local_dir,
+        parent_folder_id
+    );
 
     // Create the folder in Google Drive
     let folder_id = create_gdrive_folder(email, parent_folder_id, dir_name).await?;
 
     // Upload all contents
-    let entries = std::fs::read_dir(local_dir)
-        .map_err(|e| format!("Failed to read directory: {}", e))?;
+    let entries =
+        std::fs::read_dir(local_dir).map_err(|e| format!("Failed to read directory: {}", e))?;
 
     for entry in entries {
         let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
         let path = entry.path();
-        let name = path.file_name()
+        let name = path
+            .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
 
@@ -1788,7 +1947,10 @@ pub async fn extract_gdrive_zip(
 ) -> Result<String, String> {
     log::info!(
         "extract_gdrive_zip: email={}, file_id={}, name={}, dest={}",
-        email, file_id, file_name, destination_folder_id
+        email,
+        file_id,
+        file_name,
+        destination_folder_id
     );
 
     // Download the zip file to temp
@@ -1806,14 +1968,15 @@ pub async fn extract_gdrive_zip(
     log::info!("Extracting to temp dir: {:?}", extract_dir);
 
     // Extract the zip file
-    let zip_file = std::fs::File::open(temp_zip)
-        .map_err(|e| format!("Failed to open zip file: {}", e))?;
+    let zip_file =
+        std::fs::File::open(temp_zip).map_err(|e| format!("Failed to open zip file: {}", e))?;
 
-    let mut archive = zip::ZipArchive::new(zip_file)
-        .map_err(|e| format!("Failed to read zip archive: {}", e))?;
+    let mut archive =
+        zip::ZipArchive::new(zip_file).map_err(|e| format!("Failed to read zip archive: {}", e))?;
 
     for i in 0..archive.len() {
-        let mut file = archive.by_index(i)
+        let mut file = archive
+            .by_index(i)
             .map_err(|e| format!("Failed to read zip entry: {}", e))?;
 
         let outpath = match file.enclosed_name() {
@@ -1839,8 +2002,7 @@ pub async fn extract_gdrive_zip(
     }
 
     // Determine folder name for upload (zip name without extension)
-    let folder_name = file_name.trim_end_matches(".zip")
-        .trim_end_matches(".ZIP");
+    let folder_name = file_name.trim_end_matches(".zip").trim_end_matches(".ZIP");
 
     // Create the destination folder in Google Drive unless extracting directly
     let dest_folder_id = if create_subfolder {
@@ -1856,7 +2018,8 @@ pub async fn extract_gdrive_zip(
     for entry in entries {
         let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
         let path = entry.path();
-        let name = path.file_name()
+        let name = path
+            .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
 
@@ -1876,7 +2039,10 @@ pub async fn extract_gdrive_zip(
     let _ = std::fs::remove_file(temp_zip);
     let _ = std::fs::remove_dir_all(&extract_dir);
 
-    log::info!("Extraction and upload complete, folder ID: {}", dest_folder_id);
+    log::info!(
+        "Extraction and upload complete, folder ID: {}",
+        dest_folder_id
+    );
     Ok(dest_folder_id)
 }
 
@@ -1895,7 +2061,9 @@ pub async fn get_folder_id_by_path(email: &str, path: &str) -> Result<String, St
             if subpath.is_empty() {
                 Ok("root".to_string())
             } else {
-                provider.find_file_by_path(&hub, &subpath).await?
+                provider
+                    .find_file_by_path(&hub, &subpath)
+                    .await?
                     .ok_or_else(|| format!("Folder not found: {}", path))
             }
         }
@@ -1904,7 +2072,9 @@ pub async fn get_folder_id_by_path(email: &str, path: &str) -> Result<String, St
                 // Shared root doesn't have a single folder ID
                 Err("Cannot get folder ID for Shared with me root".to_string())
             } else {
-                provider.find_shared_file_by_path(&hub, &subpath).await?
+                provider
+                    .find_shared_file_by_path(&hub, &subpath)
+                    .await?
                     .ok_or_else(|| format!("Folder not found: {}", path))
             }
         }
@@ -1964,7 +2134,11 @@ pub async fn get_file_id_by_path(email: &str, path: &str) -> Result<String, Stri
 
 /// Check whether a file with a given name exists in a Google Drive folder.
 /// Used to avoid creating duplicate names (which break path-based navigation).
-pub async fn name_exists_in_folder(email: &str, parent_folder_id: &str, name: &str) -> Result<bool, String> {
+pub async fn name_exists_in_folder(
+    email: &str,
+    parent_folder_id: &str,
+    name: &str,
+) -> Result<bool, String> {
     let provider = GoogleDriveProvider::default();
     let hub = provider.create_hub(email).await?;
 

--- a/src-tauri/src/locations/gdrive/tests.rs
+++ b/src-tauri/src/locations/gdrive/tests.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod tests {
     use crate::locations::gdrive::auth::get_all_accounts;
-    use crate::locations::gdrive::provider::{GoogleDriveProvider, resolve_file_id_to_path};
+    use crate::locations::gdrive::provider::{resolve_file_id_to_path, GoogleDriveProvider};
     use crate::locations::{LocationInput, LocationProvider};
 
     /// Helper to check if we have any authenticated accounts
@@ -33,17 +33,30 @@ mod tests {
 
         let result = provider.read_directory(&loc).await;
 
-        assert!(result.is_ok(), "Failed to list virtual root: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Failed to list virtual root: {:?}",
+            result.err()
+        );
 
         let entries = result.unwrap();
-        assert!(!entries.entries.is_empty(), "Virtual root should have entries");
+        assert!(
+            !entries.entries.is_empty(),
+            "Virtual root should have entries"
+        );
 
         // Should have My Drive, Shared with me, etc.
         let names: Vec<_> = entries.entries.iter().map(|e| &e.name).collect();
         println!("Virtual root entries: {:?}", names);
 
-        assert!(names.contains(&&"My Drive".to_string()), "Should have My Drive");
-        assert!(names.contains(&&"Shared with me".to_string()), "Should have Shared with me");
+        assert!(
+            names.contains(&&"My Drive".to_string()),
+            "Should have My Drive"
+        );
+        assert!(
+            names.contains(&&"Shared with me".to_string()),
+            "Should have Shared with me"
+        );
     }
 
     #[tokio::test]
@@ -62,7 +75,11 @@ mod tests {
         let result = provider.read_directory(&loc).await;
         println!("My Drive result: is_ok={}", result.is_ok());
 
-        assert!(result.is_ok(), "Failed to list My Drive: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Failed to list My Drive: {:?}",
+            result.err()
+        );
     }
 
     #[tokio::test]
@@ -81,14 +98,21 @@ mod tests {
         let result = provider.read_directory(&loc).await;
         println!("Shared with me result: is_ok={}", result.is_ok());
 
-        assert!(result.is_ok(), "Failed to list Shared with me: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Failed to list Shared with me: {:?}",
+            result.err()
+        );
 
         let entries = result.unwrap();
         println!("Shared with me has {} entries", entries.entries.len());
 
         // Print first few entries to see their paths
         for entry in entries.entries.iter().take(5) {
-            println!("  - name: {}, path: {}, is_dir: {}", entry.name, entry.path, entry.is_directory);
+            println!(
+                "  - name: {}, path: {}, is_dir: {}",
+                entry.name, entry.path, entry.is_directory
+            );
         }
     }
 
@@ -115,14 +139,21 @@ mod tests {
         let folder = entries.entries.iter().find(|e| e.is_directory);
 
         if let Some(folder) = folder {
-            println!("Navigating into folder: {} at path: {}", folder.name, folder.path);
+            println!(
+                "Navigating into folder: {} at path: {}",
+                folder.name, folder.path
+            );
 
             // Navigate into it using the path from the entry
             let folder_location = location(&folder.path);
             let folder_result = provider.read_directory(&folder_location).await;
 
             println!("Folder navigation result: is_ok={}", folder_result.is_ok());
-            assert!(folder_result.is_ok(), "Failed to navigate into folder: {:?}", folder_result.err());
+            assert!(
+                folder_result.is_ok(),
+                "Failed to navigate into folder: {:?}",
+                folder_result.err()
+            );
 
             let folder_entries = folder_result.unwrap();
             println!("Folder has {} entries", folder_entries.entries.len());
@@ -161,7 +192,11 @@ mod tests {
                 let dir_result = provider.read_directory(&loc).await;
 
                 println!("Directory listing result: is_ok={}", dir_result.is_ok());
-                assert!(dir_result.is_ok(), "Failed to list resolved directory: {:?}", dir_result.err());
+                assert!(
+                    dir_result.is_ok(),
+                    "Failed to list resolved directory: {:?}",
+                    dir_result.err()
+                );
 
                 let entries = dir_result.unwrap();
                 println!("Directory has {} entries", entries.entries.len());
@@ -205,8 +240,10 @@ mod tests {
                 println!("  - {}", entry.name);
             }
         } else {
-            println!("Failed (file may not be accessible with this account): {:?}", result.err());
+            println!(
+                "Failed (file may not be accessible with this account): {:?}",
+                result.err()
+            );
         }
     }
-
 }

--- a/src-tauri/src/locations/gdrive/url_parser.rs
+++ b/src-tauri/src/locations/gdrive/url_parser.rs
@@ -173,7 +173,9 @@ mod tests {
     #[test]
     fn test_is_google_drive_url() {
         assert!(is_google_drive_url("https://drive.google.com/open?id=123"));
-        assert!(is_google_drive_url("https://docs.google.com/document/d/123/edit"));
+        assert!(is_google_drive_url(
+            "https://docs.google.com/document/d/123/edit"
+        ));
         assert!(!is_google_drive_url("https://example.com/file"));
         assert!(!is_google_drive_url("not a url"));
     }

--- a/src-tauri/src/locations/mod.rs
+++ b/src-tauri/src/locations/mod.rs
@@ -7,15 +7,15 @@ use std::sync::{Arc, RwLock};
 
 use crate::fs_utils::FileItem;
 
-mod file;
 pub mod archive;
+mod file;
 pub mod gdrive;
 pub mod sftp;
 #[cfg(not(target_os = "windows"))]
 pub mod smb;
 
-pub use file::FileSystemProvider;
 pub use archive::ArchiveProvider;
+pub use file::FileSystemProvider;
 pub use gdrive::GoogleDriveProvider;
 pub use sftp::SftpProvider;
 #[cfg(not(target_os = "windows"))]
@@ -308,7 +308,8 @@ pub trait LocationProvider: Send + Sync {
     fn scheme(&self) -> &'static str;
     fn capabilities(&self, location: &Location) -> LocationCapabilities;
 
-    async fn read_directory(&self, location: &Location) -> Result<ProviderDirectoryEntries, String>;
+    async fn read_directory(&self, location: &Location)
+        -> Result<ProviderDirectoryEntries, String>;
     async fn get_file_metadata(&self, location: &Location) -> Result<FileItem, String>;
     async fn create_directory(&self, location: &Location) -> Result<(), String>;
     async fn delete(&self, location: &Location) -> Result<(), String>;

--- a/src-tauri/src/locations/sftp/auth.rs
+++ b/src-tauri/src/locations/sftp/auth.rs
@@ -51,8 +51,11 @@ fn keyring_user(hostname: &str, port: u16, username: &str) -> String {
 }
 
 fn keyring_entry(hostname: &str, port: u16, username: &str) -> Result<keyring::Entry, String> {
-    keyring::Entry::new(SFTP_KEYRING_SERVICE, &keyring_user(hostname, port, username))
-        .map_err(|e| format!("Failed to create keyring entry: {}", e))
+    keyring::Entry::new(
+        SFTP_KEYRING_SERVICE,
+        &keyring_user(hostname, port, username),
+    )
+    .map_err(|e| format!("Failed to create keyring entry: {}", e))
 }
 
 fn set_password(hostname: &str, port: u16, username: &str, password: &str) -> Result<(), String> {
@@ -186,11 +189,16 @@ pub fn get_server_credentials(hostname: &str, port: u16) -> Result<SftpServerCre
     {
         let cache = SERVERS_CACHE.read().map_err(|e| e.to_string())?;
         if let Some(servers) = &*cache {
-            if let Some(server) = servers.iter().find(|s| {
-                s.hostname.eq_ignore_ascii_case(hostname) && s.port == port
-            }) {
+            if let Some(server) = servers
+                .iter()
+                .find(|s| s.hostname.eq_ignore_ascii_case(hostname) && s.port == port)
+            {
                 let password = if server.auth_method == "password" {
-                    Some(get_password(&server.hostname, server.port, &server.username)?)
+                    Some(get_password(
+                        &server.hostname,
+                        server.port,
+                        &server.username,
+                    )?)
                 } else if server.auth_method == "key" {
                     // Key passphrase stored in keychain (may be empty string for no passphrase)
                     get_password(&server.hostname, server.port, &server.username).ok()
@@ -226,7 +234,11 @@ pub fn get_server_credentials(hostname: &str, port: u16) -> Result<SftpServerCre
         })?;
 
     let password = if server.auth_method == "password" {
-        Some(get_password(&server.hostname, server.port, &server.username)?)
+        Some(get_password(
+            &server.hostname,
+            server.port,
+            &server.username,
+        )?)
     } else if server.auth_method == "key" {
         get_password(&server.hostname, server.port, &server.username).ok()
     } else {
@@ -252,9 +264,10 @@ pub fn add_sftp_server(
 ) -> Result<SftpServerInfo, String> {
     let mut servers = load_servers_from_disk()?;
 
-    if let Some(existing) = servers.iter_mut().find(|s| {
-        s.hostname.eq_ignore_ascii_case(&hostname) && s.port == port
-    }) {
+    if let Some(existing) = servers
+        .iter_mut()
+        .find(|s| s.hostname.eq_ignore_ascii_case(&hostname) && s.port == port)
+    {
         existing.username = username.clone();
         existing.auth_method = auth_method.clone();
         existing.key_path = key_path.clone();

--- a/src-tauri/src/locations/sftp/mod.rs
+++ b/src-tauri/src/locations/sftp/mod.rs
@@ -1,16 +1,14 @@
 pub mod auth;
 pub mod pool;
 
-use async_trait::async_trait;
-use chrono::{TimeZone, Utc};
 use crate::fs_utils::FileItem;
 use crate::locations::{
     Location, LocationCapabilities, LocationProvider, LocationSummary, ProviderDirectoryEntries,
 };
+use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
 
-pub use auth::{
-    add_sftp_server, get_sftp_servers, remove_sftp_server, SftpServerInfo,
-};
+pub use auth::{add_sftp_server, get_sftp_servers, remove_sftp_server, SftpServerInfo};
 
 #[derive(Default)]
 pub struct SftpProvider;
@@ -35,7 +33,11 @@ impl LocationProvider for SftpProvider {
 
         let (username, hostname, port) = parse_sftp_authority(authority)?;
         let path = location.path().to_string();
-        let remote_path = if path.is_empty() || path == "/" { "/" } else { &path };
+        let remote_path = if path.is_empty() || path == "/" {
+            "/"
+        } else {
+            &path
+        };
 
         let sftp = pool::get_sftp_session(&hostname, port).await?;
 
@@ -57,7 +59,10 @@ impl LocationProvider for SftpProvider {
             let is_symlink = entry.file_type().is_symlink();
             let size = entry.metadata().len();
             let mtime = entry.metadata().mtime.unwrap_or(0);
-            let modified = Utc.timestamp_opt(mtime as i64, 0).single().unwrap_or_else(Utc::now);
+            let modified = Utc
+                .timestamp_opt(mtime as i64, 0)
+                .single()
+                .unwrap_or_else(Utc::now);
 
             let extension = if !is_directory {
                 std::path::Path::new(&name)
@@ -167,7 +172,10 @@ impl LocationProvider for SftpProvider {
         let is_directory = attrs.is_dir();
         let size = attrs.len();
         let mtime = attrs.mtime.unwrap_or(0);
-        let modified = Utc.timestamp_opt(mtime as i64, 0).single().unwrap_or_else(Utc::now);
+        let modified = Utc
+            .timestamp_opt(mtime as i64, 0)
+            .single()
+            .unwrap_or_else(Utc::now);
 
         let extension = if !is_directory {
             std::path::Path::new(&name)
@@ -295,7 +303,10 @@ impl LocationProvider for SftpProvider {
 }
 
 /// Recursively delete a directory and all its contents.
-async fn recursive_delete(sftp: &russh_sftp::client::SftpSession, path: &str) -> Result<(), String> {
+async fn recursive_delete(
+    sftp: &russh_sftp::client::SftpSession,
+    path: &str,
+) -> Result<(), String> {
     let entries = sftp
         .read_dir(path)
         .await
@@ -331,9 +342,12 @@ async fn recursive_delete(sftp: &russh_sftp::client::SftpSession, path: &str) ->
 
 /// Parse authority part: "user@host:port" -> (user, host, port)
 pub fn parse_sftp_authority(authority: &str) -> Result<(String, String, u16), String> {
-    let (user_part, host_part) = authority
-        .rsplit_once('@')
-        .ok_or_else(|| format!("SFTP authority must include username: user@host (got '{}')", authority))?;
+    let (user_part, host_part) = authority.rsplit_once('@').ok_or_else(|| {
+        format!(
+            "SFTP authority must include username: user@host (got '{}')",
+            authority
+        )
+    })?;
 
     let username = user_part.to_string();
     if username.is_empty() {

--- a/src-tauri/src/locations/sftp/pool.rs
+++ b/src-tauri/src/locations/sftp/pool.rs
@@ -78,7 +78,12 @@ async fn create_session(
         client::connect(Arc::new(config), (hostname, port), SshHandler),
     )
     .await
-    .map_err(|_| format!("SSH connection to {}:{} timed out after {}s", hostname, port, CONNECT_TIMEOUT_SECS))?
+    .map_err(|_| {
+        format!(
+            "SSH connection to {}:{} timed out after {}s",
+            hostname, port, CONNECT_TIMEOUT_SECS
+        )
+    })?
     .map_err(|e| format!("SSH connection failed: {}", e))?;
 
     // Authenticate
@@ -121,10 +126,7 @@ async fn create_session(
                     .map_err(|e| format!("Failed to load SSH key: {}", e))?
             };
 
-            let key_with_alg = russh::keys::PrivateKeyWithHashAlg::new(
-                Arc::new(private_key),
-                None,
-            );
+            let key_with_alg = russh::keys::PrivateKeyWithHashAlg::new(Arc::new(private_key), None);
 
             let auth_result = session
                 .authenticate_publickey(&creds.username, key_with_alg)
@@ -274,7 +276,10 @@ pub async fn get_sftp_session(hostname: &str, port: u16) -> Result<Arc<SftpSessi
 /// Acquire a concurrency permit for the given server.
 /// Limits parallel SFTP operations to avoid overwhelming servers.
 /// Hold the returned permit for the duration of the operation.
-pub async fn acquire_permit(hostname: &str, port: u16) -> Result<tokio::sync::OwnedSemaphorePermit, String> {
+pub async fn acquire_permit(
+    hostname: &str,
+    port: u16,
+) -> Result<tokio::sync::OwnedSemaphorePermit, String> {
     let key = (hostname.to_lowercase(), port);
     let sem = {
         let pool = POOL.lock().await;

--- a/src-tauri/src/locations/smb/auth.rs
+++ b/src-tauri/src/locations/smb/auth.rs
@@ -81,9 +81,12 @@ fn set_password(hostname: &str, password: &str) -> Result<(), String> {
 
 fn get_password(hostname: &str) -> Result<String, String> {
     let entry = keyring_entry(hostname)?;
-    entry
-        .get_password()
-        .map_err(|e| format!("[SMB_NO_CREDENTIALS] Failed to read password from keychain: {}", e))
+    entry.get_password().map_err(|e| {
+        format!(
+            "[SMB_NO_CREDENTIALS] Failed to read password from keychain: {}",
+            e
+        )
+    })
 }
 
 fn delete_password(hostname: &str) -> Result<(), String> {
@@ -98,8 +101,8 @@ fn delete_password(hostname: &str) -> Result<(), String> {
 
 /// Get the path to the servers storage file
 fn get_servers_path() -> Result<PathBuf, String> {
-    let config_dir = dirs::config_dir()
-        .ok_or_else(|| "Could not determine config directory".to_string())?;
+    let config_dir =
+        dirs::config_dir().ok_or_else(|| "Could not determine config directory".to_string())?;
     let marlin_dir = config_dir.join("marlin");
 
     if !marlin_dir.exists() {
@@ -118,8 +121,8 @@ fn load_servers_from_disk() -> Result<Vec<SmbServer>, String> {
         return Ok(Vec::new());
     }
 
-    let contents = fs::read_to_string(&path)
-        .map_err(|e| format!("Failed to read servers file: {}", e))?;
+    let contents =
+        fs::read_to_string(&path).map_err(|e| format!("Failed to read servers file: {}", e))?;
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
     #[serde(rename_all = "camelCase")]
@@ -136,8 +139,8 @@ fn load_servers_from_disk() -> Result<Vec<SmbServer>, String> {
         servers: Vec<SmbServerDisk>,
     }
 
-    let storage: ServerStorageDisk =
-        serde_json::from_str(&contents).map_err(|e| format!("Failed to parse servers file: {}", e))?;
+    let storage: ServerStorageDisk = serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse servers file: {}", e))?;
 
     // Migrate any legacy plaintext passwords into the OS keychain, and rewrite file without them.
     let mut migrated = false;
@@ -173,8 +176,7 @@ fn save_servers_to_disk(servers: &[SmbServer]) -> Result<(), String> {
     let contents = serde_json::to_string_pretty(&storage)
         .map_err(|e| format!("Failed to serialize servers: {}", e))?;
 
-    fs::write(&path, contents)
-        .map_err(|e| format!("Failed to write servers file: {}", e))?;
+    fs::write(&path, contents).map_err(|e| format!("Failed to write servers file: {}", e))?;
 
     Ok(())
 }
@@ -250,7 +252,12 @@ pub fn get_server_credentials(hostname: &str) -> Result<SmbServerCredentials, St
         .iter()
         .find(|s| s.hostname.eq_ignore_ascii_case(hostname))
         .cloned()
-        .ok_or_else(|| format!("[SMB_NO_CREDENTIALS] No credentials stored for server: {}", hostname))?;
+        .ok_or_else(|| {
+            format!(
+                "[SMB_NO_CREDENTIALS] No credentials stored for server: {}",
+                hostname
+            )
+        })?;
 
     let password = get_password(&server.hostname)?;
     Ok(SmbServerCredentials {
@@ -347,9 +354,9 @@ pub fn test_smb_connection(
     if !client::is_available() {
         let status = client::initialize();
         if status != SidecarStatus::Available {
-            return Err(status.error_message().unwrap_or_else(|| {
-                "SMB support is not available".to_string()
-            }));
+            return Err(status
+                .error_message()
+                .unwrap_or_else(|| "SMB support is not available".to_string()));
         }
     }
 

--- a/src-tauri/src/locations/smb/client.rs
+++ b/src-tauri/src/locations/smb/client.rs
@@ -126,15 +126,17 @@ pub fn call_method_with_timeout<P: Serialize, R: DeserializeOwned>(
     if state.process.is_none() || state.status != SidecarStatus::Available {
         // Try to restart
         if state.restart_attempts >= MAX_RESTART_ATTEMPTS {
-            return Err(state.status.error_message().unwrap_or_else(|| {
-                "SMB sidecar is not available".to_string()
-            }));
+            return Err(state
+                .status
+                .error_message()
+                .unwrap_or_else(|| "SMB sidecar is not available".to_string()));
         }
         state.status = start_sidecar(&mut state);
         if state.status != SidecarStatus::Available {
-            return Err(state.status.error_message().unwrap_or_else(|| {
-                "SMB sidecar failed to start".to_string()
-            }));
+            return Err(state
+                .status
+                .error_message()
+                .unwrap_or_else(|| "SMB sidecar failed to start".to_string()));
         }
     }
 
@@ -188,11 +190,7 @@ pub fn call_method_with_timeout<P: Serialize, R: DeserializeOwned>(
         .and_then(|id| id.as_u64())
         .ok_or("Response missing or invalid id field")?;
     if response_id != id {
-        log::error!(
-            "Response ID mismatch: expected {}, got {}",
-            id,
-            response_id
-        );
+        log::error!("Response ID mismatch: expected {}, got {}", id, response_id);
         return Err("SMB protocol error: response ID mismatch".to_string());
     }
 
@@ -269,19 +267,30 @@ fn start_sidecar(state: &mut SidecarState) -> SidecarStatus {
     match child.try_wait() {
         Ok(Some(status)) => {
             // Process exited immediately - likely a dyld failure
-            let stderr = child.stderr.take().map(|mut s| {
-                let mut buf = String::new();
-                use std::io::Read;
-                let _ = s.read_to_string(&mut buf);
-                buf
-            }).unwrap_or_default();
+            let stderr = child
+                .stderr
+                .take()
+                .map(|mut s| {
+                    let mut buf = String::new();
+                    use std::io::Read;
+                    let _ = s.read_to_string(&mut buf);
+                    buf
+                })
+                .unwrap_or_default();
 
-            if stderr.contains("dyld") || stderr.contains("Library not loaded") || stderr.contains("libsmb") {
+            if stderr.contains("dyld")
+                || stderr.contains("Library not loaded")
+                || stderr.contains("libsmb")
+            {
                 log::warn!("Sidecar failed with dyld error: {}", stderr);
                 return SidecarStatus::LibraryMissing;
             }
 
-            log::error!("Sidecar exited immediately with status {:?}: {}", status, stderr);
+            log::error!(
+                "Sidecar exited immediately with status {:?}: {}",
+                status,
+                stderr
+            );
             return SidecarStatus::StartFailed(format!("Exited with status: {:?}", status));
         }
         Ok(None) => {
@@ -352,7 +361,8 @@ fn find_sidecar_binary() -> Option<PathBuf> {
                 // sidecar might be in Marlin.app/Contents/MacOS/ or Marlin.app/Contents/Resources/
                 if let Some(macos_dir) = exe_dir.parent() {
                     let resources_dir = macos_dir.join("Resources");
-                    let sidecar_resources = resources_dir.join(format!("marlin-smb-{}", target_triple));
+                    let sidecar_resources =
+                        resources_dir.join(format!("marlin-smb-{}", target_triple));
                     if sidecar_resources.is_file() {
                         return Some(sidecar_resources);
                     }

--- a/src-tauri/src/locations/smb/mod.rs
+++ b/src-tauri/src/locations/smb/mod.rs
@@ -1,18 +1,17 @@
 mod auth;
 pub mod client;
 
-use async_trait::async_trait;
 use crate::fs_utils::FileItem;
 use crate::locations::{
     Location, LocationCapabilities, LocationProvider, LocationSummary, ProviderDirectoryEntries,
 };
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
-pub use auth::{
-    add_smb_server, get_smb_servers, remove_smb_server, test_smb_connection,
-    SmbServerInfo,
-};
 pub use auth::get_server_credentials;
+pub use auth::{
+    add_smb_server, get_smb_servers, remove_smb_server, test_smb_connection, SmbServerInfo,
+};
 pub use client::SidecarStatus;
 
 #[derive(Default)]
@@ -36,9 +35,9 @@ impl LocationProvider for SmbProvider {
         if !client::is_available() {
             let status = client::initialize();
             if status != SidecarStatus::Available {
-                return Err(status.error_message().unwrap_or_else(|| {
-                    "SMB support is not available".to_string()
-                }));
+                return Err(status
+                    .error_message()
+                    .unwrap_or_else(|| "SMB support is not available".to_string()));
             }
         }
 
@@ -88,16 +87,23 @@ impl LocationProvider for SmbProvider {
 
         for entry in entries {
             let name = entry.get("name").and_then(|n| n.as_str()).unwrap_or("");
-            let is_directory = entry.get("is_directory").and_then(|d| d.as_bool()).unwrap_or(false);
-            let is_hidden = entry.get("is_hidden").and_then(|h| h.as_bool()).unwrap_or(false);
+            let is_directory = entry
+                .get("is_directory")
+                .and_then(|d| d.as_bool())
+                .unwrap_or(false);
+            let is_hidden = entry
+                .get("is_hidden")
+                .and_then(|h| h.as_bool())
+                .unwrap_or(false);
             let size = entry.get("size").and_then(|s| s.as_u64()).unwrap_or(0);
             let modified_str = entry.get("modified").and_then(|m| m.as_str()).unwrap_or("");
-            let extension = entry.get("extension").and_then(|e| e.as_str()).map(String::from);
+            let extension = entry
+                .get("extension")
+                .and_then(|e| e.as_str())
+                .map(String::from);
 
             // Parse modified time
-            let modified: DateTime<Utc> = modified_str
-                .parse()
-                .unwrap_or_else(|_| Utc::now());
+            let modified: DateTime<Utc> = modified_str.parse().unwrap_or_else(|_| Utc::now());
 
             let full_path = if dir_path == "/" {
                 format!("smb://{}/{}/{}", hostname, share, name)
@@ -149,9 +155,9 @@ impl LocationProvider for SmbProvider {
         if !client::is_available() {
             let status = client::initialize();
             if status != SidecarStatus::Available {
-                return Err(status.error_message().unwrap_or_else(|| {
-                    "SMB support is not available".to_string()
-                }));
+                return Err(status
+                    .error_message()
+                    .unwrap_or_else(|| "SMB support is not available".to_string()));
             }
         }
 
@@ -202,16 +208,30 @@ impl LocationProvider for SmbProvider {
         .await
         .map_err(|e| format!("SMB task failed: {}", e))??;
 
-        let name = result.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string();
-        let is_directory = result.get("is_directory").and_then(|d| d.as_bool()).unwrap_or(false);
-        let is_hidden = result.get("is_hidden").and_then(|h| h.as_bool()).unwrap_or(false);
+        let name = result
+            .get("name")
+            .and_then(|n| n.as_str())
+            .unwrap_or("")
+            .to_string();
+        let is_directory = result
+            .get("is_directory")
+            .and_then(|d| d.as_bool())
+            .unwrap_or(false);
+        let is_hidden = result
+            .get("is_hidden")
+            .and_then(|h| h.as_bool())
+            .unwrap_or(false);
         let size = result.get("size").and_then(|s| s.as_u64()).unwrap_or(0);
-        let modified_str = result.get("modified").and_then(|m| m.as_str()).unwrap_or("");
-        let extension = result.get("extension").and_then(|e| e.as_str()).map(String::from);
+        let modified_str = result
+            .get("modified")
+            .and_then(|m| m.as_str())
+            .unwrap_or("");
+        let extension = result
+            .get("extension")
+            .and_then(|e| e.as_str())
+            .map(String::from);
 
-        let modified: DateTime<Utc> = modified_str
-            .parse()
-            .unwrap_or_else(|_| Utc::now());
+        let modified: DateTime<Utc> = modified_str.parse().unwrap_or_else(|_| Utc::now());
 
         Ok(FileItem {
             name,
@@ -236,9 +256,9 @@ impl LocationProvider for SmbProvider {
         if !client::is_available() {
             let status = client::initialize();
             if status != SidecarStatus::Available {
-                return Err(status.error_message().unwrap_or_else(|| {
-                    "SMB support is not available".to_string()
-                }));
+                return Err(status
+                    .error_message()
+                    .unwrap_or_else(|| "SMB support is not available".to_string()));
             }
         }
 
@@ -273,9 +293,9 @@ impl LocationProvider for SmbProvider {
         if !client::is_available() {
             let status = client::initialize();
             if status != SidecarStatus::Available {
-                return Err(status.error_message().unwrap_or_else(|| {
-                    "SMB support is not available".to_string()
-                }));
+                return Err(status
+                    .error_message()
+                    .unwrap_or_else(|| "SMB support is not available".to_string()));
             }
         }
 
@@ -310,9 +330,9 @@ impl LocationProvider for SmbProvider {
         if !client::is_available() {
             let status = client::initialize();
             if status != SidecarStatus::Available {
-                return Err(status.error_message().unwrap_or_else(|| {
-                    "SMB support is not available".to_string()
-                }));
+                return Err(status
+                    .error_message()
+                    .unwrap_or_else(|| "SMB support is not available".to_string()));
             }
         }
 
@@ -361,9 +381,9 @@ impl LocationProvider for SmbProvider {
         if !client::is_available() {
             let status = client::initialize();
             if status != SidecarStatus::Available {
-                return Err(status.error_message().unwrap_or_else(|| {
-                    "SMB support is not available".to_string()
-                }));
+                return Err(status
+                    .error_message()
+                    .unwrap_or_else(|| "SMB support is not available".to_string()));
             }
         }
 
@@ -471,7 +491,10 @@ impl SmbProvider {
 }
 
 /// Parse an SMB path into (hostname, share, path)
-pub(crate) fn parse_smb_path(authority: &str, path: &str) -> Result<(String, String, String), String> {
+pub(crate) fn parse_smb_path(
+    authority: &str,
+    path: &str,
+) -> Result<(String, String, String), String> {
     let hostname = authority.to_string();
 
     // Path format: /share/rest/of/path
@@ -590,9 +613,9 @@ pub fn upload_file_to_smb(
     if !client::is_available() {
         let status = client::initialize();
         if status != SidecarStatus::Available {
-            return Err(status.error_message().unwrap_or_else(|| {
-                "SMB support is not available".to_string()
-            }));
+            return Err(status
+                .error_message()
+                .unwrap_or_else(|| "SMB support is not available".to_string()));
         }
     }
 
@@ -605,7 +628,10 @@ pub fn upload_file_to_smb(
         .and_then(|s| s.to_str())
         .unwrap_or(preferred_name)
         .to_string();
-    let ext = p.extension().and_then(|e| e.to_str()).map(|s| s.to_string());
+    let ext = p
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_string());
 
     for i in 1..1000usize {
         let candidate = if i == 1 {
@@ -666,9 +692,9 @@ pub fn download_file_from_smb(
     if !client::is_available() {
         let status = client::initialize();
         if status != SidecarStatus::Available {
-            return Err(status.error_message().unwrap_or_else(|| {
-                "SMB support is not available".to_string()
-            }));
+            return Err(status
+                .error_message()
+                .unwrap_or_else(|| "SMB support is not available".to_string()));
         }
     }
 
@@ -686,11 +712,8 @@ pub fn download_file_from_smb(
         "dest_path": dest_path.to_string_lossy()
     });
 
-    let _result: serde_json::Value = client::call_method_with_timeout(
-        "download_file",
-        params,
-        client::DOWNLOAD_TIMEOUT_MS,
-    )?;
+    let _result: serde_json::Value =
+        client::call_method_with_timeout("download_file", params, client::DOWNLOAD_TIMEOUT_MS)?;
 
     Ok(())
 }
@@ -701,7 +724,8 @@ mod tests {
 
     #[test]
     fn test_parse_smb_path() {
-        let (host, share, path) = parse_smb_path("server.local", "/myshare/folder/file.txt").unwrap();
+        let (host, share, path) =
+            parse_smb_path("server.local", "/myshare/folder/file.txt").unwrap();
         assert_eq!(host, "server.local");
         assert_eq!(share, "myshare");
         assert_eq!(path, "/folder/file.txt");
@@ -717,7 +741,8 @@ mod tests {
 
     #[test]
     fn test_parse_smb_url_lenient_hostname() {
-        let (host, share, path) = parse_smb_url("smb://nas_1/myshare/folder/file name.jpg").unwrap();
+        let (host, share, path) =
+            parse_smb_url("smb://nas_1/myshare/folder/file name.jpg").unwrap();
         assert_eq!(host, "nas_1");
         assert_eq!(share, "myshare");
         assert_eq!(path, "/folder/file name.jpg");

--- a/src-tauri/src/macos_icons.rs
+++ b/src-tauri/src/macos_icons.rs
@@ -5,6 +5,8 @@ use crate::macos_security;
 #[cfg(target_os = "macos")]
 use base64::Engine as _; // bring encode() into scope
 #[cfg(target_os = "macos")]
+use dirs;
+#[cfg(target_os = "macos")]
 use objc2::class;
 #[cfg(target_os = "macos")]
 use objc2::msg_send;
@@ -14,8 +16,6 @@ use objc2::rc::autoreleasepool;
 use objc2::runtime::AnyObject;
 #[cfg(target_os = "macos")]
 use objc2_foundation::{NSSize, NSString};
-#[cfg(target_os = "macos")]
-use dirs;
 #[cfg(target_os = "macos")]
 use std::collections::hash_map::DefaultHasher;
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/macos_security.rs
+++ b/src-tauri/src/macos_security.rs
@@ -8,13 +8,13 @@ mod imp {
     use std::sync::{Mutex, OnceLock};
 
     use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+    use dirs;
+    use log::warn;
     use objc2::class;
     use objc2::msg_send;
     use objc2::rc::{autoreleasepool, Retained};
     use objc2::runtime::{AnyObject, Bool};
     use objc2_foundation::{NSData, NSString, NSURL};
-    use dirs;
-    use log::warn;
     use serde::{Deserialize, Serialize};
 
     const NS_URL_BOOKMARK_CREATION_WITH_SECURITY_SCOPE: u64 = 1 << 11;
@@ -183,8 +183,7 @@ mod imp {
     unsafe fn url_for_path(path: &str) -> Result<Retained<NSURL>, String> {
         autoreleasepool(|_| unsafe {
             let ns_path = NSString::from_str(path);
-            let url: Option<Retained<NSURL>> =
-                msg_send![class!(NSURL), fileURLWithPath: &*ns_path];
+            let url: Option<Retained<NSURL>> = msg_send![class!(NSURL), fileURLWithPath: &*ns_path];
             url.ok_or_else(|| "Failed to create NSURL".to_string())
         })
     }
@@ -220,7 +219,8 @@ mod imp {
             }
             let nsdata: Option<Retained<NSData>> =
                 msg_send![class!(NSData), dataWithBytes: data.as_ptr(), length: data.len()];
-            let nsdata = nsdata.ok_or_else(|| "Failed to build NSData from bookmark".to_string())?;
+            let nsdata =
+                nsdata.ok_or_else(|| "Failed to build NSData from bookmark".to_string())?;
             let mut error: *mut AnyObject = std::ptr::null_mut();
             let mut is_stale = Bool::NO;
             let resolved: Option<Retained<NSURL>> = msg_send![

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -23,9 +23,7 @@ pub fn create_child_window_menu<R: Runtime>(
         .select_all()
         .build()?;
 
-    let menu = MenuBuilder::new(app)
-        .item(&edit_submenu)
-        .build()?;
+    let menu = MenuBuilder::new(app).item(&edit_submenu).build()?;
 
     Ok(menu)
 }

--- a/src-tauri/src/native_drag.rs
+++ b/src-tauri/src/native_drag.rs
@@ -85,7 +85,8 @@ pub fn start_native_drag(
         // Use the deprecated but more reliable dragImage method for better positioning control
         // Create NSDragPboard with file paths
         let drag_pboard_name = NSString::from_str("NSDragPboard");
-        let pb: *mut AnyObject = msg_send![class!(NSPasteboard), pasteboardWithName: &*drag_pboard_name];
+        let pb: *mut AnyObject =
+            msg_send![class!(NSPasteboard), pasteboardWithName: &*drag_pboard_name];
 
         if pb.is_null() {
             return Err("Failed to create NSDragPboard".into());

--- a/src-tauri/src/plugins/drag_detector/macos.rs
+++ b/src-tauri/src/plugins/drag_detector/macos.rs
@@ -14,7 +14,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::{Arc, Mutex};
 use tauri::{Emitter, Runtime, Window};
 
-use super::{DragDropEvent, DragEventType, DropLocation, DropZoneConfig, DragModifiers};
+use super::{DragDropEvent, DragEventType, DragModifiers, DropLocation, DropZoneConfig};
 
 type DragHandler = dyn Fn(DragDropEvent) + 'static;
 
@@ -43,8 +43,8 @@ static INITIALIZED_WINDOWS: Lazy<Mutex<HashMap<String, bool>>> =
 
 static DRAG_OVERLAY_CLASS: Lazy<&'static AnyClass> = Lazy::new(|| {
     let superclass = class!(NSView);
-    let name = CStr::from_bytes_with_nul(b"MarlinDragOverlayView\0")
-        .expect("valid overlay class name");
+    let name =
+        CStr::from_bytes_with_nul(b"MarlinDragOverlayView\0").expect("valid overlay class name");
     let mut decl = ClassBuilder::new(name, superclass).expect("create overlay class");
 
     unsafe {
@@ -67,7 +67,10 @@ static DRAG_OVERLAY_CLASS: Lazy<&'static AnyClass> = Lazy::new(|| {
 
         let prepare_for_drag_operation_fn: extern "C-unwind" fn(_, _, _) -> Bool =
             prepare_for_drag_operation;
-        decl.add_method(sel!(prepareForDragOperation:), prepare_for_drag_operation_fn);
+        decl.add_method(
+            sel!(prepareForDragOperation:),
+            prepare_for_drag_operation_fn,
+        );
 
         // Ensure normal pointer events pass through to the webview
         let hit_test_fn: extern "C-unwind" fn(_, _, _) -> Id = hit_test;
@@ -75,7 +78,10 @@ static DRAG_OVERLAY_CLASS: Lazy<&'static AnyClass> = Lazy::new(|| {
 
         let wants_periodic_dragging_updates_fn: extern "C-unwind" fn(_, _) -> Bool =
             wants_periodic_dragging_updates;
-        decl.add_method(sel!(wantsPeriodicDraggingUpdates), wants_periodic_dragging_updates_fn);
+        decl.add_method(
+            sel!(wantsPeriodicDraggingUpdates),
+            wants_periodic_dragging_updates_fn,
+        );
 
         // Add dealloc to clean up the event handler and prevent memory leaks
         let dealloc_fn: extern "C-unwind" fn(_, _) = overlay_dealloc;
@@ -144,19 +150,11 @@ extern "C-unwind" fn dragging_exited(this: Id, _sel: Sel, sender: Id) {
     }
 }
 
-extern "C-unwind" fn prepare_for_drag_operation(
-    _this: Id,
-    _sel: Sel,
-    _sender: Id,
-) -> Bool {
+extern "C-unwind" fn prepare_for_drag_operation(_this: Id, _sel: Sel, _sender: Id) -> Bool {
     Bool::YES
 }
 
-extern "C-unwind" fn perform_drag_operation(
-    this: Id,
-    _sel: Sel,
-    sender: Id,
-) -> Bool {
+extern "C-unwind" fn perform_drag_operation(this: Id, _sel: Sel, sender: Id) -> Bool {
     match catch_unwind(AssertUnwindSafe(|| {
         autoreleasepool(|_| unsafe {
             let (event, target_id) = compose_event(sender, DragEventType::Drop);
@@ -348,8 +346,7 @@ fn install_overlay<R: Runtime>(window: Window<R>) -> Result<(), String> {
         let overlay: Id = msg_send![overlay, initWithFrame: bounds];
         let _: () = msg_send![overlay, setAlphaValue: 0.0];
         let _: () = msg_send![overlay, setHidden: Bool::NO];
-        let _: () =
-            msg_send![overlay, setAutoresizingMask: NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable];
+        let _: () = msg_send![overlay, setAutoresizingMask: NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable];
 
         let handler_arc: Arc<DragHandler> = Arc::new({
             let window_clone = window.clone();

--- a/src-tauri/src/smb_sidecar/mod.rs
+++ b/src-tauri/src/smb_sidecar/mod.rs
@@ -25,7 +25,10 @@ use std::io::{BufRead, Write};
 /// This function reads JSON-RPC requests from stdin and writes responses to stdout.
 /// It exits when stdin is closed (EOF).
 pub fn run() {
-    eprintln!("[marlin-smb] Starting sidecar v{}", operations::SIDECAR_VERSION);
+    eprintln!(
+        "[marlin-smb] Starting sidecar v{}",
+        operations::SIDECAR_VERSION
+    );
 
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
@@ -51,7 +54,8 @@ pub fn run() {
             Err(e) => {
                 eprintln!("[marlin-smb] Failed to parse request: {}", e);
                 // Write a parse error response (use id 0 since we can't get the real id)
-                let response = Response::error(0, error_codes::PARSE_ERROR, format!("Parse error: {}", e));
+                let response =
+                    Response::error(0, error_codes::PARSE_ERROR, format!("Parse error: {}", e));
                 write_response(&mut stdout_lock, &response);
                 continue;
             }

--- a/src-tauri/src/smb_sidecar/operations.rs
+++ b/src-tauri/src/smb_sidecar/operations.rs
@@ -66,25 +66,25 @@ fn is_hidden_file(name: &str) -> bool {
 
 /// Read directory contents.
 pub fn read_directory(params: ReadDirectoryParams) -> Result<ReadDirectoryResult, (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
-    let client = SmbClient::new(credentials, SmbOptions::default())
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to connect to SMB server: {}", msg))
-        })?;
+    let client = SmbClient::new(credentials, SmbOptions::default()).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to connect to SMB server: {}", msg))
+    })?;
 
     // Use list_dirplus to get file metadata inline with listing
-    let entries = client
-        .list_dirplus(&params.path)
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to list directory: {}", msg))
-        })?;
+    let entries = client.list_dirplus(&params.path).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to list directory: {}", msg))
+    })?;
 
     let mut result_entries = Vec::new();
 
@@ -125,25 +125,27 @@ pub fn read_directory(params: ReadDirectoryParams) -> Result<ReadDirectoryResult
 }
 
 /// Get metadata for a single file or directory.
-pub fn get_file_metadata(params: GetFileMetadataParams) -> Result<FileMetadataResult, (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+pub fn get_file_metadata(
+    params: GetFileMetadataParams,
+) -> Result<FileMetadataResult, (i32, String)> {
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
-    let client = SmbClient::new(credentials, SmbOptions::default())
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to connect to SMB server: {}", msg))
-        })?;
+    let client = SmbClient::new(credentials, SmbOptions::default()).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to connect to SMB server: {}", msg))
+    })?;
 
-    let stat = client
-        .stat(&params.path)
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to get file metadata: {}", msg))
-        })?;
+    let stat = client.stat(&params.path).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to get file metadata: {}", msg))
+    })?;
 
     let name = std::path::Path::new(&params.path)
         .file_name()
@@ -173,17 +175,19 @@ pub fn get_file_metadata(params: GetFileMetadataParams) -> Result<FileMetadataRe
 
 /// Create a directory.
 pub fn create_directory(params: CreateDirectoryParams) -> Result<(), (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
-    let client = SmbClient::new(credentials, SmbOptions::default())
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to connect to SMB server: {}", msg))
-        })?;
+    let client = SmbClient::new(credentials, SmbOptions::default()).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to connect to SMB server: {}", msg))
+    })?;
 
     client
         .mkdir(&params.path, SmbMode::from(0o755))
@@ -195,55 +199,53 @@ pub fn create_directory(params: CreateDirectoryParams) -> Result<(), (i32, Strin
 
 /// Delete a file or directory.
 pub fn delete(params: DeleteParams) -> Result<(), (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
-    let client = SmbClient::new(credentials, SmbOptions::default())
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to connect to SMB server: {}", msg))
-        })?;
+    let client = SmbClient::new(credentials, SmbOptions::default()).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to connect to SMB server: {}", msg))
+    })?;
 
-    let stat = client
-        .stat(&params.path)
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to stat path: {}", msg))
-        })?;
+    let stat = client.stat(&params.path).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to stat path: {}", msg))
+    })?;
 
     if stat.mode.is_dir() {
-        client
-            .rmdir(&params.path)
-            .map_err(|e| {
-                let (code, msg) = map_smb_error(&e);
-                (code, format!("Failed to delete directory: {}", msg))
-            })
+        client.rmdir(&params.path).map_err(|e| {
+            let (code, msg) = map_smb_error(&e);
+            (code, format!("Failed to delete directory: {}", msg))
+        })
     } else {
-        client
-            .unlink(&params.path)
-            .map_err(|e| {
-                let (code, msg) = map_smb_error(&e);
-                (code, format!("Failed to delete file: {}", msg))
-            })
+        client.unlink(&params.path).map_err(|e| {
+            let (code, msg) = map_smb_error(&e);
+            (code, format!("Failed to delete file: {}", msg))
+        })
     }
 }
 
 /// Rename a file or directory.
 pub fn rename(params: RenameParams) -> Result<(), (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
-    let client = SmbClient::new(credentials, SmbOptions::default())
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to connect to SMB server: {}", msg))
-        })?;
+    let client = SmbClient::new(credentials, SmbOptions::default()).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to connect to SMB server: {}", msg))
+    })?;
 
     client
         .rename(&params.from_path, &params.to_path)
@@ -255,17 +257,19 @@ pub fn rename(params: RenameParams) -> Result<(), (i32, String)> {
 
 /// Copy a file.
 pub fn copy(params: CopyParams) -> Result<(), (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
-    let client = SmbClient::new(credentials, SmbOptions::default())
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to connect to SMB server: {}", msg))
-        })?;
+    let client = SmbClient::new(credentials, SmbOptions::default()).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to connect to SMB server: {}", msg))
+    })?;
 
     let mut src = client
         .open_with(&params.from_path, SmbOpenOptions::default().read(true))
@@ -277,7 +281,10 @@ pub fn copy(params: CopyParams) -> Result<(), (i32, String)> {
     let mut dst = client
         .open_with(
             &params.to_path,
-            SmbOpenOptions::default().write(true).create(true).truncate(true),
+            SmbOpenOptions::default()
+                .write(true)
+                .create(true)
+                .truncate(true),
         )
         .map_err(|e| {
             let (code, msg) = map_smb_error(&e);
@@ -320,8 +327,12 @@ pub fn list_shares(params: ListSharesParams) -> Result<ListSharesResult, (i32, S
         s
     };
 
-    std::fs::write(&auth_file_path, auth_file_contents)
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("Failed to create smbclient auth file: {}", e)))?;
+    std::fs::write(&auth_file_path, auth_file_contents).map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("Failed to create smbclient auth file: {}", e),
+        )
+    })?;
 
     #[cfg(unix)]
     {
@@ -354,7 +365,10 @@ pub fn list_shares(params: ListSharesParams) -> Result<ListSharesResult, (i32, S
                 "Authentication failed. Try using your full email as username (e.g., user@domain.com)".to_string(),
             ));
         }
-        return Err((error_codes::SMB_ERROR, format!("Failed to list shares: {}", stderr.trim())));
+        return Err((
+            error_codes::SMB_ERROR,
+            format!("Failed to list shares: {}", stderr.trim()),
+        ));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -393,10 +407,15 @@ pub fn list_shares(params: ListSharesParams) -> Result<ListSharesResult, (i32, S
 }
 
 /// Test connection to an SMB server.
-pub fn test_connection(params: TestConnectionParams) -> Result<TestConnectionResult, (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+pub fn test_connection(
+    params: TestConnectionParams,
+) -> Result<TestConnectionResult, (i32, String)> {
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let smb_url = format!("smb://{}", params.credentials.hostname);
 
@@ -421,17 +440,19 @@ pub fn test_connection(params: TestConnectionParams) -> Result<TestConnectionRes
 
 /// Download a file to a local path.
 pub fn download_file(params: DownloadFileParams) -> Result<DownloadFileResult, (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
-    let client = SmbClient::new(credentials, SmbOptions::default())
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to connect to SMB server: {}", msg))
-        })?;
+    let client = SmbClient::new(credentials, SmbOptions::default()).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to connect to SMB server: {}", msg))
+    })?;
 
     // Open the remote file for reading
     let mut smb_file = client
@@ -443,20 +464,35 @@ pub fn download_file(params: DownloadFileParams) -> Result<DownloadFileResult, (
 
     // Create parent directories if needed
     if let Some(parent) = std::path::Path::new(&params.dest_path).parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| (error_codes::INTERNAL_ERROR, format!("Failed to create temp directory: {}", e)))?;
+        std::fs::create_dir_all(parent).map_err(|e| {
+            (
+                error_codes::INTERNAL_ERROR,
+                format!("Failed to create temp directory: {}", e),
+            )
+        })?;
     }
 
     // Write to local file
-    let mut local_file = std::fs::File::create(&params.dest_path)
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("Failed to create temp file: {}", e)))?;
+    let mut local_file = std::fs::File::create(&params.dest_path).map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("Failed to create temp file: {}", e),
+        )
+    })?;
 
-    let size = std::io::copy(&mut smb_file, &mut local_file)
-        .map_err(|e| (error_codes::SMB_ERROR, format!("Failed to copy SMB file to temp: {}", e)))?;
+    let size = std::io::copy(&mut smb_file, &mut local_file).map_err(|e| {
+        (
+            error_codes::SMB_ERROR,
+            format!("Failed to copy SMB file to temp: {}", e),
+        )
+    })?;
 
-    local_file
-        .flush()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("Failed to flush temp file: {}", e)))?;
+    local_file.flush().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("Failed to flush temp file: {}", e),
+        )
+    })?;
 
     Ok(DownloadFileResult {
         path: params.dest_path,
@@ -469,9 +505,12 @@ pub fn download_file(params: DownloadFileParams) -> Result<DownloadFileResult, (
 pub fn download_partial(
     params: DownloadPartialParams,
 ) -> Result<DownloadPartialResult, (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
@@ -537,20 +576,26 @@ pub fn download_partial(
 
 /// Upload a local file to SMB.
 pub fn upload_file(params: UploadFileParams) -> Result<UploadFileResult, (i32, String)> {
-    let _guard = SMB_MUTEX
-        .lock()
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("SMB mutex poisoned: {}", e)))?;
+    let _guard = SMB_MUTEX.lock().map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("SMB mutex poisoned: {}", e),
+        )
+    })?;
 
     let credentials = build_credentials(&params.credentials, &params.share);
 
-    let client = SmbClient::new(credentials, SmbOptions::default())
-        .map_err(|e| {
-            let (code, msg) = map_smb_error(&e);
-            (code, format!("Failed to connect to SMB server: {}", msg))
-        })?;
+    let client = SmbClient::new(credentials, SmbOptions::default()).map_err(|e| {
+        let (code, msg) = map_smb_error(&e);
+        (code, format!("Failed to connect to SMB server: {}", msg))
+    })?;
 
-    let mut local_file = std::fs::File::open(&params.source_path)
-        .map_err(|e| (error_codes::INTERNAL_ERROR, format!("Failed to open source file: {}", e)))?;
+    let mut local_file = std::fs::File::open(&params.source_path).map_err(|e| {
+        (
+            error_codes::INTERNAL_ERROR,
+            format!("Failed to open source file: {}", e),
+        )
+    })?;
 
     let mut smb_file = client
         .open_with(
@@ -565,12 +610,19 @@ pub fn upload_file(params: UploadFileParams) -> Result<UploadFileResult, (i32, S
             (code, format!("Failed to open SMB destination: {}", msg))
         })?;
 
-    let size = std::io::copy(&mut local_file, &mut smb_file)
-        .map_err(|e| (error_codes::SMB_ERROR, format!("Failed to upload file: {}", e)))?;
+    let size = std::io::copy(&mut local_file, &mut smb_file).map_err(|e| {
+        (
+            error_codes::SMB_ERROR,
+            format!("Failed to upload file: {}", e),
+        )
+    })?;
 
-    smb_file
-        .flush()
-        .map_err(|e| (error_codes::SMB_ERROR, format!("Failed to flush SMB file: {}", e)))?;
+    smb_file.flush().map_err(|e| {
+        (
+            error_codes::SMB_ERROR,
+            format!("Failed to flush SMB file: {}", e),
+        )
+    })?;
 
     Ok(UploadFileResult { size })
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -77,7 +77,10 @@ pub enum TrashUndoKind {
     Unsupported,
 }
 
-#[cfg_attr(not(any(target_os = "windows", target_os = "linux", target_os = "macos")), allow(dead_code))]
+#[cfg_attr(
+    not(any(target_os = "windows", target_os = "linux", target_os = "macos")),
+    allow(dead_code)
+)]
 pub struct TrashUndoRecord {
     pub kind: TrashUndoKind,
     pub original_paths: Vec<String>,

--- a/src-tauri/src/thumbnails/cache.rs
+++ b/src-tauri/src/thumbnails/cache.rs
@@ -108,15 +108,29 @@ impl ThumbnailCache {
             if let Some(entry) = memory_cache.get_mut(&cache_key) {
                 entry.last_accessed = Utc::now();
                 self.record_hit().await;
-                return Some((entry.data_url.clone(), entry.has_transparency, entry.image_width, entry.image_height));
+                return Some((
+                    entry.data_url.clone(),
+                    entry.has_transparency,
+                    entry.image_width,
+                    entry.image_height,
+                ));
             }
         }
 
         // Try L2 disk cache
-        if let Some((data_url, has_transparency, image_width, image_height)) = self.get_from_disk(&cache_key).await {
+        if let Some((data_url, has_transparency, image_width, image_height)) =
+            self.get_from_disk(&cache_key).await
+        {
             // Promote to memory cache
-            self.put_memory(&cache_key, &data_url, 0, has_transparency, image_width, image_height)
-                .await;
+            self.put_memory(
+                &cache_key,
+                &data_url,
+                0,
+                has_transparency,
+                image_width,
+                image_height,
+            )
+            .await;
             self.record_hit().await;
             return Some((data_url, has_transparency, image_width, image_height));
         }
@@ -142,10 +156,24 @@ impl ThumbnailCache {
             .ok_or("Failed to generate cache key")?;
 
         // Store in both memory and disk cache
-        self.put_memory(&cache_key, &data_url, generation_time_ms, has_transparency, image_width, image_height)
-            .await;
-        self.put_disk(&cache_key, &data_url, generation_time_ms, has_transparency, image_width, image_height)
-            .await?;
+        self.put_memory(
+            &cache_key,
+            &data_url,
+            generation_time_ms,
+            has_transparency,
+            image_width,
+            image_height,
+        )
+        .await;
+        self.put_disk(
+            &cache_key,
+            &data_url,
+            generation_time_ms,
+            has_transparency,
+            image_width,
+            image_height,
+        )
+        .await?;
 
         // Cleanup if necessary
         self.cleanup_if_needed().await?;
@@ -258,7 +286,12 @@ impl ThumbnailCache {
             }
         }
 
-        Some((entry.data_url, entry.has_transparency, entry.image_width, entry.image_height))
+        Some((
+            entry.data_url,
+            entry.has_transparency,
+            entry.image_width,
+            entry.image_height,
+        ))
     }
 
     async fn generate_cache_key(

--- a/src-tauri/src/thumbnails/generators/fonts.rs
+++ b/src-tauri/src/thumbnails/generators/fonts.rs
@@ -63,7 +63,8 @@ impl FontGenerator {
             }
 
             // Position the glyph
-            let glyph = glyph_id.with_scale_and_position(scale, ab_glyph::point(cursor_x, baseline_y));
+            let glyph =
+                glyph_id.with_scale_and_position(scale, ab_glyph::point(cursor_x, baseline_y));
 
             // Draw the glyph
             if let Some(outlined) = scaled_font.outline_glyph(glyph) {

--- a/src-tauri/src/thumbnails/generators/mod.rs
+++ b/src-tauri/src/thumbnails/generators/mod.rs
@@ -1,20 +1,20 @@
+use super::{ThumbnailFormat, ThumbnailGenerationResult, ThumbnailQuality, ThumbnailRequest};
 use base64::Engine as _;
 use image::{DynamicImage, GenericImageView, ImageFormat};
 use std::io::Cursor;
 use std::path::Path;
-use super::{ThumbnailFormat, ThumbnailGenerationResult, ThumbnailQuality, ThumbnailRequest};
 
 #[cfg(target_os = "macos")]
 use crate::macos_security;
 #[cfg(target_os = "macos")]
 pub mod apps;
+pub mod fonts;
 pub mod images;
 pub mod pdf;
 pub mod psd;
 pub mod stl;
 pub mod svg;
 pub mod video;
-pub mod fonts;
 pub mod zpl;
 
 pub mod sftp;
@@ -76,9 +76,10 @@ impl ThumbnailGenerator {
 
             let file_id =
                 crate::locations::gdrive::provider::get_file_id_by_path(&email, &path).await?;
-            let temp_path =
-                crate::locations::gdrive::provider::download_file_to_temp(&email, &file_id, &file_name)
-                    .await?;
+            let temp_path = crate::locations::gdrive::provider::download_file_to_temp(
+                &email, &file_id, &file_name,
+            )
+            .await?;
 
             let mut prepared = request;
             prepared.path = temp_path.clone();
@@ -380,18 +381,16 @@ mod tests {
 
     #[test]
     fn test_parse_gdrive_path_basic() {
-        let (email, path) =
-            parse_gdrive_path("gdrive://brian@smg.gg/My Drive/file.zpl").unwrap();
+        let (email, path) = parse_gdrive_path("gdrive://brian@smg.gg/My Drive/file.zpl").unwrap();
         assert_eq!(email, "brian@smg.gg");
         assert_eq!(path, "/My Drive/file.zpl");
     }
 
     #[test]
     fn test_parse_gdrive_path_spaces() {
-        let (email, path) = parse_gdrive_path(
-            "gdrive://brian@smg.gg/My Drive/shipping-label-fedex real test.zpl",
-        )
-        .unwrap();
+        let (email, path) =
+            parse_gdrive_path("gdrive://brian@smg.gg/My Drive/shipping-label-fedex real test.zpl")
+                .unwrap();
         assert_eq!(email, "brian@smg.gg");
         assert_eq!(path, "/My Drive/shipping-label-fedex real test.zpl");
     }
@@ -406,10 +405,8 @@ mod tests {
 
     #[test]
     fn test_parse_gdrive_path_nested() {
-        let (email, path) = parse_gdrive_path(
-            "gdrive://a@b.co/My Drive/folder/sub folder/file name.png",
-        )
-        .unwrap();
+        let (email, path) =
+            parse_gdrive_path("gdrive://a@b.co/My Drive/folder/sub folder/file name.png").unwrap();
         assert_eq!(email, "a@b.co");
         assert_eq!(path, "/My Drive/folder/sub folder/file name.png");
     }

--- a/src-tauri/src/thumbnails/generators/pdf.rs
+++ b/src-tauri/src/thumbnails/generators/pdf.rs
@@ -18,7 +18,9 @@ impl PdfGenerator {
         Self::generate_with_mupdf(request)
     }
 
-    fn generate_with_mupdf(request: &ThumbnailRequest) -> Result<ThumbnailGenerationResult, String> {
+    fn generate_with_mupdf(
+        request: &ThumbnailRequest,
+    ) -> Result<ThumbnailGenerationResult, String> {
         // Open the PDF document with MuPDF
         let doc =
             Document::open(&request.path).map_err(|e| format!("Failed to open PDF: {:?}", e))?;

--- a/src-tauri/src/thumbnails/generators/psd.rs
+++ b/src-tauri/src/thumbnails/generators/psd.rs
@@ -56,12 +56,13 @@ impl PsdGenerator {
         // Get the pre-flattened composite image stored in the PSD
         // This is the merged/flattened image that Photoshop stores for quick preview
         // Wrap in catch_unwind to handle panics from malformed PSD files gracefully
-        let rgba_data = std::panic::catch_unwind(AssertUnwindSafe(|| psd.rgba())).map_err(|_| {
-            format!(
-                "Failed to extract image data from PSD (possibly corrupt): {}",
-                path.display()
-            )
-        })?;
+        let rgba_data =
+            std::panic::catch_unwind(AssertUnwindSafe(|| psd.rgba())).map_err(|_| {
+                format!(
+                    "Failed to extract image data from PSD (possibly corrupt): {}",
+                    path.display()
+                )
+            })?;
 
         // Create an RGBA image from the composite data
         let rgba_image = RgbaImage::from_raw(width, height, rgba_data).ok_or_else(|| {

--- a/src-tauri/src/thumbnails/generators/sftp.rs
+++ b/src-tauri/src/thumbnails/generators/sftp.rs
@@ -3,7 +3,6 @@
 //! Downloads SFTP files to a local temp directory before generating thumbnails.
 //! All network operations are async to avoid blocking tokio or rayon threads.
 
-
 /// Check if the path is an SFTP URL
 pub fn is_sftp_path(path: &str) -> bool {
     path.starts_with("sftp://")
@@ -37,4 +36,3 @@ pub async fn get_sftp_file_identity_async(
         file_id: None,
     })
 }
-

--- a/src-tauri/src/thumbnails/generators/smb.rs
+++ b/src-tauri/src/thumbnails/generators/smb.rs
@@ -111,7 +111,10 @@ fn smb_temp_path(
 }
 
 /// Clone a ThumbnailRequest with a different local file path.
-fn request_with_local_path(request: &ThumbnailRequest, local_path: &std::path::Path) -> ThumbnailRequest {
+fn request_with_local_path(
+    request: &ThumbnailRequest,
+    local_path: &std::path::Path,
+) -> ThumbnailRequest {
     let mut r = request.clone();
     r.path = local_path.to_string_lossy().to_string();
     r
@@ -168,11 +171,8 @@ fn download_smb_file_partial_sync(
         "max_bytes": max_bytes
     });
 
-    let result: serde_json::Value = client::call_method_with_timeout(
-        "download_partial",
-        params,
-        client::DOWNLOAD_TIMEOUT_MS,
-    )?;
+    let result: serde_json::Value =
+        client::call_method_with_timeout("download_partial", params, client::DOWNLOAD_TIMEOUT_MS)?;
 
     let bytes_written = result
         .get("bytes_written")
@@ -270,7 +270,11 @@ fn generate_smb_video_thumbnail(
     let local_request = request_with_local_path(request, &partial_path);
     let result = super::ThumbnailGenerator::generate_local(&local_request);
     if let Err(e) = std::fs::remove_file(&partial_path) {
-        log::warn!("Failed to remove temp file {}: {}", partial_path.display(), e);
+        log::warn!(
+            "Failed to remove temp file {}: {}",
+            partial_path.display(),
+            e
+        );
     }
 
     match result {

--- a/src-tauri/src/thumbnails/generators/video.rs
+++ b/src-tauri/src/thumbnails/generators/video.rs
@@ -1,4 +1,6 @@
-use super::super::{ThumbnailFormat, ThumbnailGenerationResult, ThumbnailQuality, ThumbnailRequest};
+use super::super::{
+    ThumbnailFormat, ThumbnailGenerationResult, ThumbnailQuality, ThumbnailRequest,
+};
 use super::ThumbnailGenerator;
 use ffmpeg_sidecar::command::FfmpegCommand;
 use ffmpeg_sidecar::download::{download_ffmpeg_package, ffmpeg_download_url, unpack_ffmpeg};

--- a/src-tauri/src/thumbnails/generators/zpl.rs
+++ b/src-tauri/src/thumbnails/generators/zpl.rs
@@ -37,8 +37,7 @@ impl ZplGenerator {
         }
 
         // Read ZPL content as raw bytes — ZPL can contain binary graphic data
-        let zpl_bytes =
-            std::fs::read(path).map_err(|e| format!("Failed to read ZPL file: {e}"))?;
+        let zpl_bytes = std::fs::read(path).map_err(|e| format!("Failed to read ZPL file: {e}"))?;
 
         // Render to PNG (serialized due to Go runtime thread safety)
         let png_bytes = {
@@ -72,11 +71,8 @@ impl ZplGenerator {
         // Resize and encode as thumbnail
         let resized = ThumbnailGenerator::resize_image(image, request.size, request.quality)?;
 
-        let data_url = ThumbnailGenerator::encode_to_data_url(
-            &resized,
-            request.format,
-            request.quality,
-        )?;
+        let data_url =
+            ThumbnailGenerator::encode_to_data_url(&resized, request.format, request.quality)?;
 
         Ok(ThumbnailGenerationResult {
             data_url,
@@ -155,7 +151,10 @@ mod tests {
             accent: None,
         };
         let err = ZplGenerator::generate(&request).unwrap_err();
-        assert!(err.contains("too large"), "expected 'too large' error, got: {err}");
+        assert!(
+            err.contains("too large"),
+            "expected 'too large' error, got: {err}"
+        );
     }
 
     #[test]
@@ -170,6 +169,9 @@ mod tests {
             accent: None,
         };
         let err = ZplGenerator::generate(&request).unwrap_err();
-        assert!(err.contains("metadata"), "expected metadata error, got: {err}");
+        assert!(
+            err.contains("metadata"),
+            "expected metadata error, got: {err}"
+        );
     }
 }

--- a/src-tauri/src/thumbnails/mod.rs
+++ b/src-tauri/src/thumbnails/mod.rs
@@ -321,7 +321,10 @@ mod tests {
         };
         let key1 = generate_cache_key("test.jpg", 128, &id1, None);
         let key2 = generate_cache_key("test.jpg", 128, &id2, None);
-        assert_ne!(key1, key2, "Keys should differ when file_id (inode) differs");
+        assert_ne!(
+            key1, key2,
+            "Keys should differ when file_id (inode) differs"
+        );
     }
 
     #[test]
@@ -392,21 +395,16 @@ mod tests {
             mtime_ns: 12345,
             file_id: Some(1),
         };
-        let accent1 = AccentColor {
-            r: 255,
-            g: 0,
-            b: 0,
-        };
-        let accent2 = AccentColor {
-            r: 0,
-            g: 255,
-            b: 0,
-        };
+        let accent1 = AccentColor { r: 255, g: 0, b: 0 };
+        let accent2 = AccentColor { r: 0, g: 255, b: 0 };
         let key1 = generate_cache_key("test.jpg", 128, &id, Some(&accent1));
         let key2 = generate_cache_key("test.jpg", 128, &id, Some(&accent2));
         let key3 = generate_cache_key("test.jpg", 128, &id, None);
         assert_ne!(key1, key2, "Keys should differ when accent colors differ");
-        assert_ne!(key1, key3, "Keys should differ when one has accent and other doesn't");
+        assert_ne!(
+            key1, key3,
+            "Keys should differ when one has accent and other doesn't"
+        );
     }
 
     #[test]
@@ -487,7 +485,8 @@ mod tests {
         );
 
         // Verify the identities actually differ
-        let differs = id1.size != id2.size || id1.mtime_ns != id2.mtime_ns || id1.file_id != id2.file_id;
+        let differs =
+            id1.size != id2.size || id1.mtime_ns != id2.mtime_ns || id1.file_id != id2.file_id;
         assert!(
             differs,
             "File identity should differ after delete and recreate"

--- a/src-tauri/src/thumbnails/worker.rs
+++ b/src-tauri/src/thumbnails/worker.rs
@@ -163,8 +163,13 @@ impl ThumbnailWorker {
                         let prepared = match ThumbnailGenerator::prepare(request.clone()).await {
                             Ok(p) => p,
                             Err(e) => {
-                                log::warn!("THUMBNAIL PREPARE FAILED: path={}, error={}", request.path, e);
-                                let _ = response_sender.send(Err(format!("Thumbnail preparation failed: {}", e)));
+                                log::warn!(
+                                    "THUMBNAIL PREPARE FAILED: path={}, error={}",
+                                    request.path,
+                                    e
+                                );
+                                let _ = response_sender
+                                    .send(Err(format!("Thumbnail preparation failed: {}", e)));
                                 drop(permit);
                                 return;
                             }
@@ -221,7 +226,11 @@ impl ThumbnailWorker {
                                 })
                             }
                             Ok(Err(e)) => {
-                                log::warn!("THUMBNAIL GENERATION FAILED: path={}, error={}", request.path, e);
+                                log::warn!(
+                                    "THUMBNAIL GENERATION FAILED: path={}, error={}",
+                                    request.path,
+                                    e
+                                );
                                 Err(format!("Thumbnail generation failed: {}", e))
                             }
                             Err(e) => {

--- a/src-tauri/tests/smb_integration.rs
+++ b/src-tauri/tests/smb_integration.rs
@@ -25,7 +25,8 @@ fn env_or(name: &str, default: &str) -> String {
 #[test]
 #[ignore]
 fn smb_can_list_shares() {
-    let server = env("MARLIN_SMB_TEST_SERVER").expect("Set MARLIN_SMB_TEST_SERVER to run this test");
+    let server =
+        env("MARLIN_SMB_TEST_SERVER").expect("Set MARLIN_SMB_TEST_SERVER to run this test");
     let provider = SmbProvider::default();
     let location = Location::parse(&format!("smb://{server}/")).expect("Invalid SMB URL");
 
@@ -44,7 +45,8 @@ fn smb_can_list_shares() {
 #[test]
 #[ignore]
 fn smb_can_list_directory() {
-    let server = env("MARLIN_SMB_TEST_SERVER").expect("Set MARLIN_SMB_TEST_SERVER to run this test");
+    let server =
+        env("MARLIN_SMB_TEST_SERVER").expect("Set MARLIN_SMB_TEST_SERVER to run this test");
     let share = env("MARLIN_SMB_TEST_SHARE").expect("Set MARLIN_SMB_TEST_SHARE to run this test");
     let path = env_or("MARLIN_SMB_TEST_PATH", "/");
 
@@ -70,4 +72,3 @@ fn smb_can_list_directory() {
         Err(err) => panic!("Failed to list directory for {url}: {err}"),
     }
 }
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,12 +64,21 @@ function isPermissionErrorMessage(errorCode: string | null, errorMessage: string
   return errorCode === ErrorCodes.EPERM || errorMessage.includes('Operation not permitted');
 }
 
+function isMacTrashPath(path: string) {
+  return path.replace(/\/+$/, '').endsWith('/.Trash');
+}
+
 async function requestFolderAccessForPath(path: string): Promise<boolean> {
   if (platform() !== 'macos') return false;
 
-  const folderName = basename(path) || path;
+  const requestsTrashAccess = isMacTrashPath(path);
+  const folderName = requestsTrashAccess ? 'Trash' : basename(path) || path;
+  const folderToSelect = requestsTrashAccess ? dirname(path) : path;
+  const folderToSelectLabel = requestsTrashAccess
+    ? basename(folderToSelect) || folderToSelect
+    : folderName;
   const shouldSelectFolder = await ask(
-    `Marlin needs permission to open "${folderName}". Select this folder in the next dialog to grant access.`,
+    `Marlin needs permission to open "${folderName}". Select "${folderToSelectLabel}" in the next dialog to grant access.`,
     {
       title: 'Folder Access Required',
       okLabel: 'Select Folder',
@@ -81,12 +90,12 @@ async function requestFolderAccessForPath(path: string): Promise<boolean> {
   if (!shouldSelectFolder) return false;
 
   const selection = await openDialog({
-    title: `Grant Access to ${folderName}`,
+    title: `Grant Access to ${folderToSelectLabel}`,
     directory: true,
     multiple: false,
     recursive: true,
     canCreateDirectories: false,
-    defaultPath: path,
+    defaultPath: folderToSelect,
     fileAccessMode: 'scoped',
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,11 +11,11 @@ import { useToastStore } from './store/useToastStore';
 import { useUndoStore } from './store/useUndoStore';
 import { openFolderSizeWindow } from './store/useFolderSizeStore';
 import { useDirectoryStream } from './hooks/useDirectoryStream';
-import { message } from '@tauri-apps/plugin-dialog';
+import { ask, message, open as openDialog } from '@tauri-apps/plugin-dialog';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { platform } from '@tauri-apps/plugin-os';
 import { getEffectiveExtension, isArchiveFile } from './utils/fileTypes';
-import { dirname } from './utils/pathUtils';
+import { basename, dirname } from './utils/pathUtils';
 import { applyAccentVariables, DEFAULT_ACCENT, normalizeHexColor } from '@/utils/accent';
 import { getSuggestedZipName } from './utils/zipNaming';
 import { revealInFileBrowser } from '@/utils/fileBrowser';
@@ -59,6 +59,56 @@ function hasUriScheme(path: string): boolean {
 }
 
 const ACCENT_POLL_INTERVAL_MS = 5000;
+
+function isPermissionErrorMessage(errorCode: string | null, errorMessage: string) {
+  return errorCode === ErrorCodes.EPERM || errorMessage.includes('Operation not permitted');
+}
+
+async function requestFolderAccessForPath(path: string): Promise<boolean> {
+  if (platform() !== 'macos') return false;
+
+  const folderName = basename(path) || path;
+  const shouldSelectFolder = await ask(
+    `Marlin needs permission to open "${folderName}". Select this folder in the next dialog to grant access.`,
+    {
+      title: 'Folder Access Required',
+      okLabel: 'Select Folder',
+      cancelLabel: 'Cancel',
+      kind: 'warning',
+    }
+  );
+
+  if (!shouldSelectFolder) return false;
+
+  const selection = await openDialog({
+    title: `Grant Access to ${folderName}`,
+    directory: true,
+    multiple: false,
+    recursive: true,
+    canCreateDirectories: false,
+    defaultPath: path,
+    fileAccessMode: 'scoped',
+  });
+
+  if (!selection) return false;
+
+  const selectedPath = Array.isArray(selection) ? selection[0] : selection;
+  if (!selectedPath) return false;
+
+  await invoke('authorize_folder_access', { path: selectedPath });
+  return true;
+}
+
+async function retryCurrentDirectoryAfterAccessGrant(path: string) {
+  const state = useAppStore.getState();
+  if (path.includes('://')) {
+    await state.refreshCurrentDirectory();
+  } else {
+    await state.refreshCurrentDirectoryStreaming();
+  }
+
+  return !useAppStore.getState().error;
+}
 
 // Grid zoom constants (for keyboard shortcuts - wheel handler moved to MainPanel)
 import {
@@ -720,18 +770,26 @@ function App() {
         }
 
         // Show alert for all other directory access errors
-        const isPermissionError =
-          errorCode === ErrorCodes.EPERM || errorMessage.includes('Operation not permitted');
-        const hint = isPermissionError
-          ? '\n\nAllow Marlin under System Settings → Privacy & Security → Files and Folders.'
-          : '';
+        const isPermissionError = isPermissionErrorMessage(errorCode, errorMessage);
+
+        if (isPermissionError) {
+          try {
+            const accessGranted = await requestFolderAccessForPath(currentPath);
+            if (accessGranted && (await retryCurrentDirectoryAfterAccessGrant(currentPath))) {
+              setError(undefined);
+              return;
+            }
+          } catch (accessError) {
+            console.warn('Failed to request folder access:', accessError);
+          }
+        }
 
         // This was a failed navigation, not a render-state error.
         setLoading(false);
         setError(undefined);
 
         // Show native alert dialog
-        await message(`Cannot access: ${currentPath}\n\n${errorMessage}${hint}`, {
+        await message(`Cannot access: ${currentPath}\n\n${errorMessage}`, {
           title: 'Directory Error',
           okLabel: 'OK',
           kind: 'error',
@@ -1691,10 +1749,22 @@ function App() {
             });
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            const hint = msg.includes('Operation not permitted')
-              ? ' Grant access under System Settings → Privacy & Security → Files and Folders.'
-              : '';
-            await message(`Failed to refresh: ${msg}${hint}`, {
+            const errorCode = parseErrorCode(err);
+            const isPermissionError = isPermissionErrorMessage(errorCode, msg);
+
+            if (isPermissionError) {
+              try {
+                const accessGranted = await requestFolderAccessForPath(currentPath);
+                if (accessGranted && (await retryCurrentDirectoryAfterAccessGrant(currentPath))) {
+                  setError(undefined);
+                  return;
+                }
+              } catch (accessError) {
+                console.warn('Failed to request folder access:', accessError);
+              }
+            }
+
+            await message(`Failed to refresh: ${msg}`, {
               title: 'Refresh Error',
               okLabel: 'OK',
               kind: 'error',

--- a/src/components/FileGrid.tsx
+++ b/src/components/FileGrid.tsx
@@ -271,7 +271,13 @@ export default function FileGrid({ files, preferences }: FileGridProps) {
     cancelRename: cancelRenameAction,
     justCreatedPath,
   } = useAppStore();
-  const { startNativeDrag, endNativeDrag, isDraggedDirectory } = useDragStore();
+  const {
+    startNativeDrag,
+    endNativeDrag,
+    isDraggedDirectory,
+    setNativeDragPaths,
+    clearNativeDragPaths,
+  } = useDragStore();
   const dropTargetPath = useDragStore((s) => s.dropTargetPath);
   const [renameText, setRenameText] = useState<string>('');
   const [draggedFile, setDraggedFile] = useState<string | null>(null);
@@ -534,6 +540,8 @@ export default function FileGrid({ files, preferences }: FileGridProps) {
               return;
             }
 
+            setNativeDragPaths(dragPaths);
+
             // Use new unified native drag API
             await invoke('start_native_drag', {
               paths: dragPaths,
@@ -545,6 +553,7 @@ export default function FileGrid({ files, preferences }: FileGridProps) {
           } finally {
             // Clear dragging state
             setDraggedFile(null);
+            window.setTimeout(clearNativeDragPaths, 500);
             // If we were tracking a directory drag, end it
             if (file.is_directory) {
               endNativeDrag();

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -213,7 +213,13 @@ export default function FileList({ files, preferences }: FileListProps) {
     cancelRename: cancelRenameAction,
     justCreatedPath,
   } = useAppStore();
-  const { startNativeDrag, endNativeDrag, isDraggedDirectory } = useDragStore();
+  const {
+    startNativeDrag,
+    endNativeDrag,
+    isDraggedDirectory,
+    setNativeDragPaths,
+    clearNativeDragPaths,
+  } = useDragStore();
   const dropTargetPath = useDragStore((s) => s.dropTargetPath);
   const [renameText, setRenameText] = useState<string>('');
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -516,6 +522,8 @@ export default function FileList({ files, preferences }: FileListProps) {
               return;
             }
 
+            setNativeDragPaths(dragPaths);
+
             // Use new unified native drag API
             await invoke('start_native_drag', {
               paths: dragPaths,
@@ -527,6 +535,7 @@ export default function FileList({ files, preferences }: FileListProps) {
           } finally {
             // Clear dragging state
             setDraggedFile(null);
+            window.setTimeout(clearNativeDragPaths, 500);
             // If we were tracking a directory drag, end it
             if (file.is_directory) {
               endNativeDrag();

--- a/src/components/PathBar.tsx
+++ b/src/components/PathBar.tsx
@@ -196,6 +196,8 @@ export default function PathBar() {
   const suggestionRequestIdRef = useRef(0);
   const startNativeDrag = useDragStore((state) => state.startNativeDrag);
   const endNativeDrag = useDragStore((state) => state.endNativeDrag);
+  const setNativeDragPaths = useDragStore((state) => state.setNativeDragPaths);
+  const clearNativeDragPaths = useDragStore((state) => state.clearNativeDragPaths);
   const setInAppDropTargetId = useDragStore((state) => state.setInAppDropTargetId);
   const dropTargetPath = useDragStore((state) => state.dropTargetPath);
 
@@ -579,6 +581,7 @@ export default function PathBar() {
           }
 
           cleanup();
+          setNativeDragPaths([currentPath]);
           void invoke('start_native_drag', {
             paths: [currentPath],
             previewImage: null,
@@ -588,6 +591,7 @@ export default function PathBar() {
               console.warn('Native drag failed for current directory:', error);
             })
             .finally(() => {
+              window.setTimeout(clearNativeDragPaths, 500);
               endNativeDrag();
             });
           return;
@@ -606,7 +610,15 @@ export default function PathBar() {
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onMouseUp);
     },
-    [currentDirMeta, currentPath, endNativeDrag, setInAppDropTargetId, startNativeDrag]
+    [
+      clearNativeDragPaths,
+      currentDirMeta,
+      currentPath,
+      endNativeDrag,
+      setInAppDropTargetId,
+      setNativeDragPaths,
+      startNativeDrag,
+    ]
   );
 
   return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -47,6 +47,18 @@ type SidebarLink = {
   weight: 'fill' | 'regular';
 };
 
+const SYSTEM_DRIVE_REFRESH_INTERVAL_MS = 5000;
+
+const areSystemDrivesEqual = (a: SystemDrive[], b: SystemDrive[]) =>
+  a.length === b.length &&
+  a.every(
+    (drive, index) =>
+      drive.name === b[index]?.name &&
+      drive.path === b[index]?.path &&
+      drive.drive_type === b[index]?.drive_type &&
+      drive.is_ejectable === b[index]?.is_ejectable
+  );
+
 export default function Sidebar() {
   const {
     currentPath,
@@ -233,22 +245,46 @@ export default function Sidebar() {
     }
   );
 
-  // Fetch system drives, Google accounts, and SMB servers on component mount
-  useEffect(() => {
-    fetchSystemDrives();
-    loadGoogleAccounts();
-    loadSmbServers();
-    loadSftpServers();
-  }, [loadGoogleAccounts, loadSmbServers, loadSftpServers]);
-
-  const fetchSystemDrives = async () => {
+  const fetchSystemDrives = useCallback(async () => {
     try {
       const drives = await invoke<SystemDrive[]>('get_system_drives');
-      setSystemDrives(drives);
+      setSystemDrives((current) => (areSystemDrivesEqual(current, drives) ? current : drives));
     } catch (error) {
       console.error('Failed to fetch system drives:', error);
     }
-  };
+  }, []);
+
+  // Fetch system drives, Google accounts, and SMB servers on component mount
+  useEffect(() => {
+    void fetchSystemDrives();
+    loadGoogleAccounts();
+    loadSmbServers();
+    loadSftpServers();
+  }, [fetchSystemDrives, loadGoogleAccounts, loadSmbServers, loadSftpServers]);
+
+  // Removable drives can mount after the sidebar is already rendered.
+  useEffect(() => {
+    const refreshVisibleDrives = () => {
+      if (document.visibilityState === 'visible') {
+        void fetchSystemDrives();
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      refreshVisibleDrives();
+    };
+
+    window.addEventListener('focus', refreshVisibleDrives);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    const intervalId = window.setInterval(refreshVisibleDrives, SYSTEM_DRIVE_REFRESH_INTERVAL_MS);
+
+    return () => {
+      window.removeEventListener('focus', refreshVisibleDrives);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.clearInterval(intervalId);
+    };
+  }, [fetchSystemDrives]);
 
   const handleEjectDrive = async (drive: SystemDrive, event: React.MouseEvent) => {
     event.stopPropagation(); // Prevent navigation when clicking eject

--- a/src/hooks/useDragDetector.ts
+++ b/src/hooks/useDragDetector.ts
@@ -22,9 +22,15 @@ const localDirnameForDrop = (path: string) => {
   return normalized.slice(0, lastSlash);
 };
 
-const isSameDirectoryDrop = (paths: string[], targetPath: string) => {
+const isSameLocationDrop = (paths: string[], targetPath: string) => {
   const normalizedTarget = normalizeLocalPathForDrop(targetPath);
-  return paths.length > 0 && paths.every((path) => localDirnameForDrop(path) === normalizedTarget);
+  return (
+    paths.length > 0 &&
+    paths.every((path) => {
+      const normalizedPath = normalizeLocalPathForDrop(path);
+      return normalizedPath === normalizedTarget || localDirnameForDrop(path) === normalizedTarget;
+    })
+  );
 };
 
 export interface DragDropEvent {
@@ -50,6 +56,12 @@ export interface DragDropHandlers {
  * This uses a custom Tauri plugin to detect drops that the native drag API can't handle
  */
 export function useDragDetector(handlers: DragDropHandlers) {
+  const handlersRef = useRef(handlers);
+
+  useEffect(() => {
+    handlersRef.current = handlers;
+  }, [handlers]);
+
   const enableDragDetection = useCallback(async () => {
     try {
       await invoke('enable_drag_detection');
@@ -77,13 +89,15 @@ export function useDragDetector(handlers: DragDropHandlers) {
     let unlisten: UnlistenFn | null = null;
     let lastTargetId: string | null = null;
     let lastLogTime = 0;
+    let disposed = false;
 
     const setupListener = async () => {
       // Enable drag detection when component mounts
       await enableDragDetection();
+      if (disposed) return;
 
       // Listen for drag-drop events from the plugin
-      unlisten = await listen<DragDropEvent>('drag-drop-event', (event) => {
+      const nextUnlisten = await listen<DragDropEvent>('drag-drop-event', (event) => {
         // Only handle hover/highlight events when this window is focused
         // This prevents unfocused windows from showing dropzone highlights
         // But allow drop events through - during cross-app drags, target window
@@ -141,13 +155,13 @@ export function useDragDetector(handlers: DragDropHandlers) {
 
         switch (normalizedEvent.eventType) {
           case 'dragEnter':
-            handlers.onDragEnter?.(normalizedEvent);
+            handlersRef.current.onDragEnter?.(normalizedEvent);
             break;
           case 'dragOver':
             if (normalizedEvent.location.targetId) {
-              handlers.onDragOver?.(normalizedEvent);
+              handlersRef.current.onDragOver?.(normalizedEvent);
             } else {
-              handlers.onDragLeave?.({
+              handlersRef.current.onDragLeave?.({
                 ...normalizedEvent,
                 eventType: 'dragLeave',
                 location: {
@@ -158,25 +172,32 @@ export function useDragDetector(handlers: DragDropHandlers) {
             }
             break;
           case 'dragLeave':
-            handlers.onDragLeave?.(normalizedEvent);
+            handlersRef.current.onDragLeave?.(normalizedEvent);
             break;
           case 'drop':
-            handlers.onDrop?.(normalizedEvent);
+            handlersRef.current.onDrop?.(normalizedEvent);
             break;
         }
       });
+
+      if (disposed) {
+        nextUnlisten();
+      } else {
+        unlisten = nextUnlisten;
+      }
     };
 
     setupListener();
 
     return () => {
+      disposed = true;
       if (unlisten) {
         unlisten();
       }
       lastTargetId = null;
       lastLogTime = 0;
     };
-  }, [handlers, enableDragDetection]);
+  }, [enableDragDetection]);
 
   return {
     setDropZone,
@@ -353,7 +374,11 @@ export function useFilePanelDropZone(
           }
         }
 
-        if (isSameDirectoryDrop(event.paths, targetPath)) {
+        const activeNativeDragPaths = useDragStore.getState().nativeDragPaths;
+        if (
+          isSameLocationDrop(event.paths, targetPath) ||
+          isSameLocationDrop(activeNativeDragPaths, targetPath)
+        ) {
           setIsDraggingOver(false);
           setDropTargetPath(null);
           setPendingDropOperation(null);

--- a/src/hooks/useDragDetector.ts
+++ b/src/hooks/useDragDetector.ts
@@ -12,6 +12,21 @@ export interface DragModifiers {
 
 const SAME_LOCATION_DROP_REASON = 'NO_OP_SAME_LOCATION';
 
+const normalizeLocalPathForDrop = (path: string) =>
+  path.replace(/\\/g, '/').replace(/\/+$/, '') || '/';
+
+const localDirnameForDrop = (path: string) => {
+  const normalized = normalizeLocalPathForDrop(path);
+  const lastSlash = normalized.lastIndexOf('/');
+  if (lastSlash <= 0) return '/';
+  return normalized.slice(0, lastSlash);
+};
+
+const isSameDirectoryDrop = (paths: string[], targetPath: string) => {
+  const normalizedTarget = normalizeLocalPathForDrop(targetPath);
+  return paths.length > 0 && paths.every((path) => localDirnameForDrop(path) === normalizedTarget);
+};
+
 export interface DragDropEvent {
   paths: string[];
   location: {
@@ -336,6 +351,14 @@ export function useFilePanelDropZone(
           if (folderPath) {
             targetPath = folderPath;
           }
+        }
+
+        if (isSameDirectoryDrop(event.paths, targetPath)) {
+          setIsDraggingOver(false);
+          setDropTargetPath(null);
+          setPendingDropOperation(null);
+          operationCache.current.clear();
+          return;
         }
 
         // Dedupe rapid drops (include target to allow different destinations)

--- a/src/hooks/useDragDetector.ts
+++ b/src/hooks/useDragDetector.ts
@@ -10,6 +10,8 @@ export interface DragModifiers {
   cmdCtrl: boolean;
 }
 
+const SAME_LOCATION_DROP_REASON = 'NO_OP_SAME_LOCATION';
+
 export interface DragDropEvent {
   paths: string[];
   location: {
@@ -359,6 +361,10 @@ export function useFilePanelDropZone(
 
         // Final validation and execution
         void resolveOperation(event.paths, targetPath, event.modifiers).then(async (opInfo) => {
+          if (opInfo.reason === SAME_LOCATION_DROP_REASON) {
+            return;
+          }
+
           if (!opInfo.valid) {
             useToastStore.getState().addToast({
               type: 'error',

--- a/src/store/useDragStore.ts
+++ b/src/store/useDragStore.ts
@@ -8,6 +8,8 @@ interface DraggedDirectory {
 interface DragStore {
   // Native drag tracking (for directories being dragged to external apps or sidebar)
   nativeDragDirectory: DraggedDirectory | null;
+  // Paths placed on the native pasteboard by this app while a native drag is active.
+  nativeDragPaths: string[];
   // In-app hover target for non-native drags
   inAppDropTargetId: string | null;
   dropTargetPath: string | null;
@@ -16,6 +18,8 @@ interface DragStore {
 
   // Start tracking a native drag of a directory
   startNativeDrag: (directory: DraggedDirectory) => void;
+  setNativeDragPaths: (paths: string[]) => void;
+  clearNativeDragPaths: () => void;
   // End tracking of native drag
   endNativeDrag: () => void;
   // Check if a specific path is being dragged
@@ -29,6 +33,7 @@ interface DragStore {
 
 export const useDragStore = create<DragStore>((set, get) => ({
   nativeDragDirectory: null,
+  nativeDragPaths: [],
   inAppDropTargetId: null,
   dropTargetPath: null,
   pendingDropOperation: null,
@@ -38,6 +43,14 @@ export const useDragStore = create<DragStore>((set, get) => ({
     set({
       nativeDragDirectory: directory,
     });
+  },
+
+  setNativeDragPaths: (paths: string[]) => {
+    set({ nativeDragPaths: paths });
+  },
+
+  clearNativeDragPaths: () => {
+    set({ nativeDragPaths: [] });
   },
 
   endNativeDrag: () => {


### PR DESCRIPTION
## Summary

Fixes two file browser refresh/access issues and applies the approved Rust formatting pass.

- Refreshes the sidebar drive list while the app is visible and when the window regains focus, so newly mounted removable drives appear without reloading the window.
- Preflights streaming local directory reads with `read_dir`, so macOS permission failures surface immediately instead of leaving the main panel spinning forever.
- Adds a macOS folder access recovery flow: when a protected folder read is denied, Marlin prompts the user to select that folder, stores a security-scoped bookmark, and retries the directory load.
- Runs `cargo fmt --all` across the Tauri codebase.

## Root Cause

The drive list was fetched only when the sidebar mounted or after ejecting a drive, so mounts that happened later were invisible until a full window reload.

The streaming directory command returned success after basic path checks, then performed the actual `read_dir` in a background task. If macOS denied that background read, no error reached React and `loading` stayed true.

## Validation

- `npm run typecheck`
- `npx eslint src/App.tsx src/components/Sidebar.tsx`
- `npx prettier --check src/App.tsx src/components/Sidebar.tsx`
- `cd src-tauri && cargo fmt --all --check`
- `cd src-tauri && RUSTFLAGS="-D warnings" cargo check`
- Pre-push `npm run check` hook