### PR TITLE
fix: repair release workflow build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,9 @@ jobs:
           fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n');
           NODE
 
+      - name: Format version metadata
+        run: npx --yes prettier@3.6.2 --write package.json package-lock.json src-tauri/tauri.conf.json
+
       - name: Detect changes
         id: diff
         run: |
@@ -446,13 +449,8 @@ jobs:
             ${{ runner.os == 'macOS' && '--bundles app updater' || '' }}
             ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '--bundles deb' || '' }}
 
-      - name: Create and notarize DMG (macOS)
+      - name: Create DMG (macOS)
         if: runner.os == 'macOS'
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
           TARGET_DIR="${CARGO_TARGET_DIR:-src-tauri/target}"
@@ -467,20 +465,54 @@ jobs:
 
           # Create a temporary directory with the app and Applications symlink
           STAGING=$(mktemp -d)
+          trap 'rm -rf "$STAGING"' EXIT
           cp -R "$APP_PATH" "$STAGING/"
           ln -s /Applications "$STAGING/Applications"
 
           # Create DMG using hdiutil (no AppleScript/Finder needed)
           # Use arch-specific volume name to avoid "Resource busy" when two
           # macOS runners create DMGs on the same machine simultaneously.
+          created=false
           for attempt in 1 2 3; do
-            hdiutil create -volname "Marlin-${ARCH}" -srcfolder "$STAGING" -ov -format UDZO "$DMG_PATH" && break
-            echo "hdiutil attempt $attempt failed, retrying in 10s..."
-            sleep 10
+            rm -f "$DMG_PATH"
+            hdiutil detach "/Volumes/Marlin-${ARCH}" -force || true
+            if hdiutil create -volname "Marlin-${ARCH}" -srcfolder "$STAGING" -ov -format UDZO "$DMG_PATH"; then
+              created=true
+              break
+            fi
+            echo "hdiutil attempt $attempt failed."
+            if [ "$attempt" -lt 3 ]; then
+              echo "Retrying in 10s..."
+              sleep 10
+            fi
           done
-          rm -rf "$STAGING"
 
-          # Notarize the DMG
+          if [ "$created" != "true" ]; then
+            echo "Failed to create $DMG_PATH after 3 attempts." >&2
+            exit 1
+          fi
+
+          echo "DMG created: $DMG_PATH"
+
+      - name: Notarize DMG (macOS)
+        if: runner.os == 'macOS'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          TARGET_DIR="${CARGO_TARGET_DIR:-src-tauri/target}"
+          ARCH="${{ matrix.arch }}"
+          VERSION="${RELEASE_TAG#v}"
+          DMG_NAME="Marlin_${VERSION}_${ARCH}.dmg"
+          DMG_PATH="$TARGET_DIR/${{ matrix.target }}/release/bundle/dmg/$DMG_NAME"
+
+          if [ -z "${APPLE_ID:-}" ] || [ -z "${APPLE_PASSWORD:-}" ] || [ -z "${APPLE_TEAM_ID:-}" ]; then
+            echo "Apple notarization credentials are not configured." >&2
+            exit 1
+          fi
+
           echo "Notarizing $DMG_NAME..."
           xcrun notarytool submit "$DMG_PATH" \
             --apple-id "$APPLE_ID" \
@@ -488,7 +520,6 @@ jobs:
             --team-id "$APPLE_TEAM_ID" \
             --wait
 
-          # Staple the notarization ticket
           xcrun stapler staple "$DMG_PATH"
           echo "DMG notarized and stapled: $DMG_PATH"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,9 +41,7 @@
       "icons/128x128.png",
       "icons/32x32.png"
     ],
-    "externalBin": [
-      "binaries/marlin-smb"
-    ],
+    "externalBin": ["binaries/marlin-smb"],
     "linux": {
       "deb": {
         "files": {
@@ -54,9 +52,7 @@
     "macOS": {
       "entitlements": "./Entitlements.plist",
       "signingIdentity": null,
-      "frameworks": [
-        "lib/libzpl.dylib"
-      ]
+      "frameworks": ["lib/libzpl.dylib"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- format release-bot version metadata before committing version bumps
- keep the current Tauri config in Prettier format so Check passes
- split macOS DMG creation from notarization and make DMG creation retries fail correctly
- keep notarization failures as hard failures now that the Apple agreement has been accepted

## Testing
- npm run check
- npx prettier --check .github/workflows/release.yml src-tauri/tauri.conf.json
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release.yml parses'"
- git diff --check