### PR TITLE
fix(ci): refresh Rust workspace caches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,8 @@ jobs:
         with:
           workspaces: |
             src-tauri -> target
-          shared-key: release-${{ matrix.target }}
+          # v2 invalidates caches created before workspace crates were retained.
+          shared-key: release-v2-${{ matrix.target }}
           cache-all-crates: true
           cache-workspace-crates: true
           cache-on-failure: true
@@ -684,7 +685,8 @@ jobs:
         with:
           workspaces: |
             src-tauri -> target
-          shared-key: release-${{ matrix.target }}
+          # v2 invalidates caches created before workspace crates were retained.
+          shared-key: release-v2-${{ matrix.target }}
           cache-all-crates: true
           cache-workspace-crates: true
           cache-on-failure: true


### PR DESCRIPTION
## What changed

- version the Rust cache namespace for release and dry-run jobs
- force creation of caches that retain workspace crate artifacts

## Root cause

The existing cache key predated `cache-workspace-crates: true`. GitHub Actions caches are immutable, so successful full-key restores continued loading the old dependency-only archive. macOS then rebuilt the Marlin workspace for 8–11 minutes despite the apparent cache hit.

## Expected impact

After this PR merges, the default-branch run will seed fresh cache entries containing both app and SMB workspace build variants. Subsequent PRs should avoid those recompilations.

## Validation

- `npm run check`
- `git diff --check`
- successful workflow syntax loading will be verified by this PR run