### PR TITLE
fix(ci): cache Rust compiler outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,17 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      - name: Set up Rust compiler cache
+        if: ${{ !matrix.self_hosted }}
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable Rust compiler cache
+        if: ${{ !matrix.self_hosted }}
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_RW_MODE=${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}" >> "$GITHUB_ENV"
+
       # Tauri caching only needed for GitHub-hosted runners
       - name: Prepare Tauri cache directory (Linux)
         if: runner.os == 'Linux' && !matrix.self_hosted
@@ -691,6 +702,17 @@ jobs:
           cache-workspace-crates: true
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Set up Rust compiler cache
+        if: ${{ !matrix.self_hosted }}
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable Rust compiler cache
+        if: ${{ !matrix.self_hosted }}
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_RW_MODE=${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}" >> "$GITHUB_ENV"
 
       # Tauri caching only needed for GitHub-hosted runners
       - name: Prepare Tauri cache directory (Linux)


### PR DESCRIPTION
## What changed

- install `sccache` on GitHub-hosted release runners
- route Rust compilation through the GitHub Actions-backed compiler cache
- keep PR cache access read-only while allowing `master` and release runs to populate it

## Root cause

The target-directory cache restores successfully, but fresh checkout timestamps invalidate workspace targets. macOS consequently spends another 8–11 minutes recompiling optimized Rust code. `sccache` keys compiler outputs by their actual inputs instead of target-directory timestamps.

## Expected impact

After the first `master` seed run, unchanged Rust dependencies and workspace crates can be served from the compiler cache while preserving the existing full macOS bundle checks.

## Validation

- `npm run check`
- `git diff --check`
- official `mozilla-actions/sccache-action@v0.0.10` configuration