### PR TITLE
fix(ci): remove regressive compiler cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,17 +308,6 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      - name: Set up Rust compiler cache
-        if: ${{ !matrix.self_hosted }}
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Enable Rust compiler cache
-        if: ${{ !matrix.self_hosted }}
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_GHA_RW_MODE=${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}" >> "$GITHUB_ENV"
-
       # Tauri caching only needed for GitHub-hosted runners
       - name: Prepare Tauri cache directory (Linux)
         if: runner.os == 'Linux' && !matrix.self_hosted
@@ -702,17 +691,6 @@ jobs:
           cache-workspace-crates: true
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Set up Rust compiler cache
-        if: ${{ !matrix.self_hosted }}
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Enable Rust compiler cache
-        if: ${{ !matrix.self_hosted }}
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_GHA_RW_MODE=${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}" >> "$GITHUB_ENV"
 
       # Tauri caching only needed for GitHub-hosted runners
       - name: Prepare Tauri cache directory (Linux)


### PR DESCRIPTION
## Summary
- remove the sccache layer from release and dry-run jobs
- retain the refreshed Cargo target caches

## Evidence
A no-change warm-cache measurement regressed Apple Silicon from 11m17s to 15m36s and Intel from 12m20s to 18m11s. ARM achieved a 75.43% compiler-cache hit rate, but cache reads took about 110 seconds and 967 native compilations still missed. Intel had no cacheable compiler calls because the remaining work is dominated by final linking.

## Validation
- `npm run check`
- `git diff --check`