### PR TITLE
fix: prevent duplicate filesystem watcher entries

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3642,106 +3642,42 @@ pub async fn clipboard_paste_image_to_location(
         return Ok(result);
     }
 
-    #[cfg(all(feature = "smb", not(target_os = "windows")))]
+    #[cfg(not(target_os = "windows"))]
     if dest_scheme == "smb" {
-        use crate::locations::smb::get_server_credentials;
-        use crate::locations::smb::SMB_MUTEX;
-        use pavao::{SmbClient, SmbCredentials, SmbOpenOptions, SmbOptions};
-        use std::io::{Cursor, ErrorKind};
-
         let dest_authority = dest_location
             .authority()
             .ok_or_else(|| "SMB destination missing server".to_string())?;
         let (hostname, share, dir_path) =
             crate::locations::smb::parse_smb_path(dest_authority, dest_location.path())?;
-        let creds = get_server_credentials(&hostname)?;
 
-        let hostname_clone = hostname.clone();
-        let share_clone = share.clone();
-        let dir_path_clone = dir_path.clone();
-        let creds_username = creds.username.clone();
-        let creds_password = creds.password.clone();
-        let creds_domain = creds.domain.clone();
+        // The main app talks to SMB through the sidecar; it must never link pavao or
+        // libsmbclient directly. Write the clipboard image to a temporary local file
+        // and reuse the same collision-safe upload path as regular file pastes.
+        let temp_dir = std::env::temp_dir().join("marlin-clipboard-cache");
+        tokio::fs::create_dir_all(&temp_dir)
+            .await
+            .map_err(|e| format!("Failed to create temp directory: {e}"))?;
+        let temp_path = temp_dir.join(format!("smb_upload_{}.png", uuid::Uuid::new_v4()));
+        tokio::fs::write(&temp_path, &image_bytes)
+            .await
+            .map_err(|e| format!("Failed to write temp file: {e}"))?;
 
-        let candidate_name = tokio::task::spawn_blocking(move || -> Result<String, String> {
-            let _guard = SMB_MUTEX
-                .lock()
-                .map_err(|e| format!("SMB mutex poisoned: {e}"))?;
-
-            let smb_url = format!("smb://{}", hostname_clone);
-            let share_path = if share_clone.starts_with('/') {
-                share_clone.clone()
-            } else {
-                format!("/{}", share_clone)
-            };
-
-            let mut credentials = SmbCredentials::default()
-                .server(&smb_url)
-                .share(&share_path)
-                .username(&creds_username)
-                .password(&creds_password);
-
-            if let Some(domain) = &creds_domain {
-                credentials = credentials.workgroup(domain);
-            }
-
-            let client = SmbClient::new(credentials, SmbOptions::default())
-                .map_err(|e| format!("Failed to connect: {e}"))?;
-
-            let (stem, ext) = {
-                let p = std::path::Path::new(&base_name);
-                let stem = p
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("Screenshot")
-                    .to_string();
-                let ext = p
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .map(|s| s.to_string());
-                (stem, ext)
-            };
-
-            for i in 1..1000usize {
-                let candidate = if i == 1 {
-                    base_name.clone()
-                } else if let Some(ref e) = ext {
-                    format!("{stem} ({i}).{e}")
-                } else {
-                    format!("{stem} ({i})")
-                };
-
-                let dest_rel = if dir_path_clone == "/" {
-                    format!("/{}", candidate)
-                } else {
-                    format!("{}/{}", dir_path_clone.trim_end_matches('/'), candidate)
-                };
-
-                let options = SmbOpenOptions::default()
-                    .write(true)
-                    .create(true)
-                    .exclusive(true);
-                match client.open_with(&dest_rel, options) {
-                    Ok(mut dest_file) => {
-                        let mut cursor = Cursor::new(&image_bytes[..]);
-                        std::io::copy(&mut cursor, &mut dest_file)
-                            .map_err(|e| format!("Failed to upload: {e}"))?;
-                        dest_file
-                            .flush()
-                            .map_err(|e| format!("Failed to flush: {e}"))?;
-                        return Ok(candidate);
-                    }
-                    Err(pavao::SmbError::Io(io)) if io.kind() == ErrorKind::AlreadyExists => {
-                        continue
-                    }
-                    Err(e) => return Err(format!("Failed to create destination: {e}")),
-                }
-            }
-
-            Err("Unable to allocate unique destination name".to_string())
+        let temp_path_for_upload = temp_path.clone();
+        let base_name_for_upload = base_name.clone();
+        let upload_result = tokio::task::spawn_blocking(move || {
+            crate::locations::smb::upload_file_to_smb(
+                &temp_path_for_upload,
+                &hostname,
+                &share,
+                &dir_path,
+                &base_name_for_upload,
+            )
         })
         .await
-        .map_err(|e| format!("Task failed: {e}"))??;
+        .map_err(|e| format!("Task failed: {e}"));
+
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        let candidate_name = upload_result??;
 
         let dest_raw = if dest_location.raw().ends_with('/') {
             format!("{}{}", dest_location.raw(), candidate_name)

--- a/src-tauri/src/fs_watcher.rs
+++ b/src-tauri/src/fs_watcher.rs
@@ -11,10 +11,16 @@ use crate::macos_security;
 
 #[derive(Debug)]
 pub struct FsWatcher {
-    watchers: Arc<Mutex<HashMap<String, RecommendedWatcher>>>,
+    watchers: Arc<Mutex<HashMap<String, WatchRegistration>>>,
     app_handle: AppHandle,
     #[cfg(target_os = "macos")]
     scope_tokens: Arc<Mutex<HashMap<String, macos_security::AccessToken>>>,
+}
+
+#[derive(Debug)]
+struct WatchRegistration {
+    _watcher: RecommendedWatcher,
+    subscribers: usize,
 }
 
 impl FsWatcher {
@@ -43,13 +49,15 @@ impl FsWatcher {
         #[cfg(target_os = "macos")]
         let scope_token = macos_security::retain_access(&path_buf)?;
 
-        // Check if already watching this path
+        // React effects can briefly overlap during navigation or Strict Mode. Keep a
+        // reference count so an older cleanup cannot tear down a newer registration.
         {
-            let watchers = self.watchers.lock().unwrap();
-            if watchers.contains_key(&normalized_path) {
+            let mut watchers = self.watchers.lock().unwrap();
+            if let Some(registration) = watchers.get_mut(&normalized_path) {
+                registration.subscribers += 1;
                 #[cfg(target_os = "macos")]
                 drop(scope_token);
-                return Ok(()); // Already watching
+                return Ok(());
             }
         }
 
@@ -77,10 +85,29 @@ impl FsWatcher {
             .watch(&path_buf, RecursiveMode::NonRecursive)
             .map_err(|e| format!("Failed to start watching: {}", e))?;
 
-        // Store the watcher
-        {
+        // Store the watcher. Check again under the insertion lock because another
+        // start may have completed while this watcher was being constructed.
+        let joined_existing_registration = {
             let mut watchers = self.watchers.lock().unwrap();
-            watchers.insert(normalized_path.clone(), watcher);
+            if let Some(registration) = watchers.get_mut(&normalized_path) {
+                registration.subscribers += 1;
+                true
+            } else {
+                watchers.insert(
+                    normalized_path.clone(),
+                    WatchRegistration {
+                        _watcher: watcher,
+                        subscribers: 1,
+                    },
+                );
+                false
+            }
+        };
+
+        if joined_existing_registration {
+            #[cfg(target_os = "macos")]
+            drop(scope_token);
+            return Ok(());
         }
 
         #[cfg(target_os = "macos")]
@@ -229,16 +256,25 @@ impl FsWatcher {
         let normalized_path = PathBuf::from(path).to_string_lossy().to_string();
 
         let mut watchers = self.watchers.lock().unwrap();
-        if watchers.remove(&normalized_path).is_some() {
+        let should_remove = match watchers.get_mut(&normalized_path) {
+            Some(registration) if registration.subscribers > 1 => {
+                registration.subscribers -= 1;
+                false
+            }
+            Some(_) => true,
+            None => return Err("Path is not being watched".to_string()),
+        };
+
+        if should_remove {
+            watchers.remove(&normalized_path);
             #[cfg(target_os = "macos")]
             {
                 let mut tokens = self.scope_tokens.lock().unwrap();
                 tokens.remove(&normalized_path);
             }
-            Ok(())
-        } else {
-            Err("Path is not being watched".to_string())
         }
+
+        Ok(())
     }
 
     pub fn stop_all_watchers(&self) {

--- a/src-tauri/src/locations/smb/auth.rs
+++ b/src-tauri/src/locations/smb/auth.rs
@@ -25,10 +25,8 @@ pub struct SmbServer {
 }
 
 /// Server credentials resolved from keychain (internal use)
-#[cfg_attr(not(feature = "smb"), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub struct SmbServerCredentials {
-    pub hostname: String,
     pub username: String,
     pub password: String,
     pub domain: Option<String>,
@@ -218,7 +216,6 @@ pub fn get_smb_servers() -> Result<Vec<SmbServerInfo>, String> {
 }
 
 /// Get credentials for a specific server (internal use)
-#[cfg_attr(not(feature = "smb"), allow(dead_code))]
 pub fn get_server_credentials(hostname: &str) -> Result<SmbServerCredentials, String> {
     // Check cache first
     {
@@ -230,7 +227,6 @@ pub fn get_server_credentials(hostname: &str) -> Result<SmbServerCredentials, St
             {
                 let password = get_password(&server.hostname)?;
                 return Ok(SmbServerCredentials {
-                    hostname: server.hostname.clone(),
                     username: server.username.clone(),
                     password,
                     domain: server.domain.clone(),
@@ -261,7 +257,6 @@ pub fn get_server_credentials(hostname: &str) -> Result<SmbServerCredentials, St
 
     let password = get_password(&server.hostname)?;
     Ok(SmbServerCredentials {
-        hostname: server.hostname,
         username: server.username,
         password,
         domain: server.domain,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { useToastStore } from './store/useToastStore';
 import { useUndoStore } from './store/useUndoStore';
 import { openFolderSizeWindow } from './store/useFolderSizeStore';
 import { useDirectoryStream } from './hooks/useDirectoryStream';
+import { useDirectoryWatcher } from '@/hooks/useDirectoryWatcher';
 import { ask, message, open as openDialog } from '@tauri-apps/plugin-dialog';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { platform } from '@tauri-apps/plugin-os';
@@ -28,10 +29,7 @@ import {
   SMB_CONNECT_SUCCESS_EVENT,
   SFTP_CONNECT_SUCCESS_EVENT,
 } from '@/utils/events';
-import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
-import { invalidateThumbnailsForPaths } from '@/hooks/useThumbnail';
 import type {
-  DirectoryChangeEventPayload,
   DirectoryListingResponse,
   FileItem,
   PersistedPreferences,
@@ -159,11 +157,9 @@ function App() {
   const globalPreferences = useAppStore((state) => state.globalPreferences);
   const loadPinnedDirectories = useAppStore((state) => state.loadPinnedDirectories);
 
-  // Animation preference hook (reactive to system changes)
-  const prefersReducedMotion = usePrefersReducedMotion();
-
   // Set up directory streaming event listener
   useDirectoryStream();
+  useDirectoryWatcher(currentPath);
 
   const initializedRef = useRef(false);
   const [showLoadingOverlay, setShowLoadingOverlay] = useState(false);
@@ -827,186 +823,6 @@ function App() {
 
     loadDirectory();
   }, [currentPath, navigateTo, setError, setLoading, setCurrentPath]);
-
-  // File system watcher for auto-reload
-  useEffect(() => {
-    if (!currentPath || loading) {
-      return;
-    }
-
-    let isActive = true;
-    let debounceTimer: number | undefined;
-    let cleanupFunction: (() => void) | undefined;
-
-    const handleDirectoryChanged = (event: Event<DirectoryChangeEventPayload>) => {
-      if (!isActive) return;
-
-      const payload = event.payload;
-
-      // Skip access-only changes (e.g., opening a file updates atime)
-      // Only refresh for actual content changes: create, delete, rename, write, modify
-      const changeType = (payload?.changeType || '').toLowerCase();
-      const isContentChange =
-        changeType === 'created' ||
-        changeType === 'removed' ||
-        changeType === 'modified' ||
-        changeType === 'renamed' ||
-        changeType === 'changed'; // Catch-all for other modification events
-
-      // Normalize paths for comparison (strip trailing slashes)
-      const normalizedPayloadPath = payload?.path?.replace(/\/+$/, '') || '';
-      const normalizedCurrentPath = currentPath.replace(/\/+$/, '');
-
-      if (payload && normalizedPayloadPath === normalizedCurrentPath && isContentChange) {
-        // Invalidate frontend thumbnail cache for modified/removed files
-        // (created files don't have cached thumbnails yet)
-        if (
-          (changeType === 'modified' || changeType === 'removed') &&
-          payload.affectedPaths &&
-          payload.affectedPaths.length > 0
-        ) {
-          invalidateThumbnailsForPaths(payload.affectedPaths);
-        }
-
-        // Clear any existing debounce timer
-        if (debounceTimer) {
-          window.clearTimeout(debounceTimer);
-        }
-
-        // Debounce the refresh to avoid excessive reloads
-        debounceTimer = window.setTimeout(async () => {
-          if (!isActive || loading) {
-            return;
-          }
-
-          try {
-            const state = useAppStore.getState();
-            const { files: currentFiles, selectedFiles } = state;
-            const affectedFiles = payload.affectedFiles || [];
-
-            // For small changes, try to update locally without full refresh
-            if (affectedFiles.length > 0 && affectedFiles.length <= 10) {
-              // Build paths of affected files using a Set for O(1) lookups
-              const affectedPaths = new Set(
-                affectedFiles.map((name: string) =>
-                  currentPath.endsWith('/') ? `${currentPath}${name}` : `${currentPath}/${name}`
-                )
-              );
-
-              // Check which affected files exist in our current list (potential removals)
-              const filesToRemove = currentFiles.filter((f) => affectedPaths.has(f.path));
-
-              // Verify they're actually gone by checking if they exist on disk
-              // We'll do this by checking if they're in the new file list after a quick refresh
-              const response = await invoke<{ entries: FileItem[] }>('read_directory', {
-                path: currentPath,
-              }).catch(() => null);
-
-              if (response) {
-                const newFilePaths = new Set(response.entries.map((f: FileItem) => f.path));
-                const confirmedRemovals = filesToRemove.filter((f) => !newFilePaths.has(f.path));
-
-                // O(N+M) lookup for new files instead of O(N*M)
-                const currentFilesByPath = new Map(currentFiles.map((cf) => [cf.path, cf]));
-                const newFiles = response.entries.filter(
-                  (f: FileItem) => !currentFilesByPath.has(f.path)
-                );
-
-                // Find modified files - either:
-                // 1. Files in affectedPaths (we KNOW they changed from fs-watcher)
-                // 2. Files with different mtime/size (fallback detection)
-                const modifiedFiles = response.entries.filter((f: FileItem) => {
-                  const existing = currentFilesByPath.get(f.path);
-                  if (!existing) return false;
-
-                  // If this file is in the affected list from fs-watcher, always consider it modified
-                  // This handles cases where mtime precision might not detect the change
-                  const isAffected = affectedPaths.has(f.path);
-
-                  // Also detect changes via mtime/size comparison
-                  const hasMetadataChange =
-                    existing.modified !== f.modified || existing.size !== f.size;
-
-                  return isAffected || hasMetadataChange;
-                });
-
-                // Handle removals with animation
-                if (confirmedRemovals.length > 0 && !prefersReducedMotion) {
-                  const removedPaths = confirmedRemovals.map((f) => f.path);
-                  state.markFilesExiting(removedPaths);
-                } else if (confirmedRemovals.length > 0) {
-                  // Reduced motion: remove immediately using store action
-                  const removedPathsSet = new Set(confirmedRemovals.map((r) => r.path));
-                  state.removeFilesByPath(removedPathsSet);
-                }
-
-                // Handle modified files - update metadata so thumbnails refresh
-                if (modifiedFiles.length > 0) {
-                  state.updateFiles(modifiedFiles);
-                }
-
-                // Handle new files - just add to list, components will handle entry animation
-                if (newFiles.length > 0) {
-                  state.addFiles(newFiles);
-                }
-
-                // Update selection
-                if (selectedFiles.length > 0) {
-                  const stillExist = selectedFiles.filter((path) => newFilePaths.has(path));
-                  if (stillExist.length !== selectedFiles.length) {
-                    state.setSelectedFiles(stillExist);
-                  }
-                }
-
-                return; // Skip full refresh
-              }
-            }
-
-            // Fallback: full refresh for large changes or when quick check fails
-            await useAppStore.getState().refreshCurrentDirectoryStreaming();
-          } catch (error) {
-            console.warn('Auto-refresh failed:', error);
-            // Fallback to full refresh on error
-            void useAppStore.getState().refreshCurrentDirectoryStreaming();
-          }
-        }, 500); // 500ms debounce
-      }
-    };
-
-    const setupWatcher = async () => {
-      if (!isActive) return;
-
-      try {
-        // Start watching current directory
-        await invoke('start_watching_directory', { path: currentPath });
-
-        // Listen for directory change events
-        const unlisten = await listen('directory-changed', handleDirectoryChanged);
-
-        // Store cleanup function
-        cleanupFunction = () => {
-          unlisten();
-          invoke('stop_watching_directory', { path: currentPath }).catch(() => {
-            // Ignore errors during cleanup
-          });
-        };
-      } catch (error) {
-        console.warn('Failed to setup file watcher:', error);
-      }
-    };
-
-    setupWatcher();
-
-    return () => {
-      isActive = false;
-      if (debounceTimer) {
-        window.clearTimeout(debounceTimer);
-      }
-      if (cleanupFunction) {
-        cleanupFunction();
-      }
-    };
-  }, [currentPath, loading, prefersReducedMotion]);
 
   // Persist only current directory prefs on change to avoid global clobbering
   useEffect(() => {

--- a/src/__tests__/unit/hooks/useDirectoryWatcher.test.ts
+++ b/src/__tests__/unit/hooks/useDirectoryWatcher.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type Event } from '@tauri-apps/api/event';
+import { useDirectoryWatcher } from '@/hooks/useDirectoryWatcher';
+import { useAppStore } from '@/store/useAppStore';
+import type { DirectoryChangeEventPayload, DirectoryListingResponse, FileItem } from '@/types';
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('@/hooks/useThumbnail', () => ({ invalidateThumbnailsForPaths: vi.fn() }));
+
+const mockInvoke = vi.mocked(invoke);
+const mockListen = vi.mocked(listen);
+
+const downloadedFile: FileItem = {
+  name: 'download.zip',
+  path: '/test/download.zip',
+  size: 20,
+  modified: '2024-01-01T00:00:00.000Z',
+  is_directory: false,
+  is_hidden: false,
+  is_symlink: false,
+  is_git_repo: false,
+  extension: 'zip',
+};
+
+const listing: DirectoryListingResponse = {
+  entries: [downloadedFile],
+  location: {
+    raw: 'file:///test',
+    scheme: 'file',
+    authority: null,
+    path: '/test',
+    displayPath: '/test',
+  },
+  capabilities: {
+    scheme: 'file',
+    displayName: 'Local Filesystem',
+    canRead: true,
+    canWrite: true,
+    canCreateDirectories: true,
+    canDelete: true,
+    canRename: true,
+    canCopy: true,
+    canMove: true,
+    supportsWatching: true,
+    requiresExplicitRefresh: false,
+  },
+};
+
+describe('useDirectoryWatcher', () => {
+  let directoryChanged: ((event: Event<DirectoryChangeEventPayload>) => void) | undefined;
+  const unlisten = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    directoryChanged = undefined;
+    useAppStore.setState({
+      currentPath: '/test',
+      files: [],
+      selectedFiles: [],
+      streamingSessionId: null,
+      isStreamingComplete: true,
+    });
+
+    mockListen.mockImplementation(async (_event, handler) => {
+      directoryChanged = handler;
+      return unlisten;
+    });
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'read_directory') return listing;
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('coalesces event bursts into one authoritative reconciliation', async () => {
+    const { unmount } = renderHook(() => useDirectoryWatcher('/test'));
+    await act(async () => Promise.resolve());
+
+    const event: Event<DirectoryChangeEventPayload> = {
+      event: 'directory-changed',
+      id: 1,
+      payload: {
+        path: '/test',
+        changeType: 'modified',
+        affectedFiles: ['download.zip'],
+        affectedPaths: ['/test/download.zip'],
+      },
+    };
+
+    act(() => {
+      directoryChanged?.(event);
+      directoryChanged?.(event);
+      directoryChanged?.(event);
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(400));
+
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, 'start_watching_directory', { path: '/test' });
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'read_directory', { path: '/test' });
+    expect(useAppStore.getState().files).toEqual([downloadedFile]);
+
+    unmount();
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/unit/store/useAppStore.test.ts
+++ b/src/__tests__/unit/store/useAppStore.test.ts
@@ -254,6 +254,45 @@ describe('useAppStore', () => {
       expect(file?.image_width).toBe(1920);
       expect(file?.image_height).toBe(1080);
     });
+
+    it('deduplicates an authoritative listing by path', () => {
+      const path = '/test/download.zip';
+      const baseFile = {
+        name: 'download.zip',
+        path,
+        size: 10,
+        modified: '2024-01-01T00:00:00.000Z',
+        is_directory: false,
+        is_hidden: false,
+        is_symlink: false,
+        is_git_repo: false,
+        extension: 'zip',
+      };
+
+      useAppStore.getState().setFiles([baseFile, { ...baseFile, size: 20 }]);
+
+      expect(useAppStore.getState().files).toEqual([{ ...baseFile, size: 20 }]);
+    });
+
+    it('upserts repeated additions instead of appending duplicate rows', () => {
+      const path = '/test/download.zip';
+      const baseFile = {
+        name: 'download.zip',
+        path,
+        size: 10,
+        modified: '2024-01-01T00:00:00.000Z',
+        is_directory: false,
+        is_hidden: false,
+        is_symlink: false,
+        is_git_repo: false,
+        extension: 'zip',
+      };
+
+      useAppStore.getState().addFiles([baseFile]);
+      useAppStore.getState().addFiles([{ ...baseFile, size: 20 }]);
+
+      expect(useAppStore.getState().files).toEqual([{ ...baseFile, size: 20 }]);
+    });
   });
 
   describe('refreshCurrentDirectory', () => {
@@ -883,6 +922,23 @@ describe('useAppStore', () => {
 
         const state = useAppStore.getState();
         expect(state.streamingTotalCount).toBe(100);
+      });
+
+      it('should not duplicate a path repeated by overlapping batches', () => {
+        useAppStore.setState({
+          streamingSessionId: 'session-1',
+          files: [mockFile1],
+          isStreamingComplete: false,
+        });
+
+        useAppStore.getState().appendStreamingBatch({
+          sessionId: 'session-1',
+          batchIndex: 1,
+          entries: [{ ...mockFile1, size: 250 }],
+          isFinal: false,
+        });
+
+        expect(useAppStore.getState().files).toEqual([{ ...mockFile1, size: 250 }]);
       });
     });
 

--- a/src/hooks/useDirectoryWatcher.ts
+++ b/src/hooks/useDirectoryWatcher.ts
@@ -1,0 +1,135 @@
+import { useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { useAppStore } from '@/store/useAppStore';
+import { invalidateThumbnailsForPaths } from '@/hooks/useThumbnail';
+import type { DirectoryChangeEventPayload, DirectoryListingResponse } from '@/types';
+
+const RECONCILE_DELAY_MS = 400;
+const STREAMING_RETRY_MS = 200;
+
+const comparablePath = (path: string) => path.replace(/[\\/]+$/, '');
+
+/**
+ * Treat filesystem notifications only as invalidation signals. The directory
+ * listing remains authoritative, and every refresh replaces the store by path.
+ */
+export function useDirectoryWatcher(currentPath: string) {
+  useEffect(() => {
+    if (!currentPath || /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(currentPath)) return;
+
+    let cancelled = false;
+    let watcherStarted = false;
+    let unlisten: UnlistenFn | undefined;
+    let reconcileTimer: number | undefined;
+    let reconcileInFlight = false;
+    let reconcileAgain = false;
+
+    const watchedPath = comparablePath(currentPath);
+
+    const scheduleReconciliation = (delay = RECONCILE_DELAY_MS) => {
+      if (cancelled) return;
+      if (reconcileTimer !== undefined) window.clearTimeout(reconcileTimer);
+      reconcileTimer = window.setTimeout(() => {
+        reconcileTimer = undefined;
+        void reconcileDirectory();
+      }, delay);
+    };
+
+    const reconcileDirectory = async () => {
+      if (cancelled) return;
+
+      const initialState = useAppStore.getState();
+      if (initialState.streamingSessionId && !initialState.isStreamingComplete) {
+        scheduleReconciliation(STREAMING_RETRY_MS);
+        return;
+      }
+
+      if (reconcileInFlight) {
+        reconcileAgain = true;
+        return;
+      }
+
+      reconcileInFlight = true;
+      try {
+        do {
+          reconcileAgain = false;
+          const response = await invoke<DirectoryListingResponse>('read_directory', {
+            path: currentPath,
+          });
+
+          if (cancelled) return;
+
+          const state = useAppStore.getState();
+          if (comparablePath(state.currentPath) !== watchedPath) return;
+
+          // This is an authoritative snapshot. setFiles preserves computed metadata
+          // while enforcing exactly one item for each filesystem path.
+          state.setFiles(response.entries);
+
+          if (state.selectedFiles.length > 0) {
+            const existingPaths = new Set(response.entries.map((file) => file.path));
+            const selectedFiles = state.selectedFiles.filter((path) => existingPaths.has(path));
+            if (selectedFiles.length !== state.selectedFiles.length) {
+              state.setSelectedFiles(selectedFiles);
+            }
+          }
+        } while (!cancelled && reconcileAgain);
+      } catch (error) {
+        if (!cancelled) console.warn('Directory watcher reconciliation failed:', error);
+      } finally {
+        reconcileInFlight = false;
+      }
+    };
+
+    const setup = async () => {
+      try {
+        // Listen first so changes cannot fall into a gap between starting the native
+        // watcher and registering the frontend callback.
+        const stopListening = await listen<DirectoryChangeEventPayload>(
+          'directory-changed',
+          (event) => {
+            if (cancelled || comparablePath(event.payload.path) !== watchedPath) return;
+
+            const changeType = event.payload.changeType.toLowerCase();
+            if (
+              (changeType === 'modified' || changeType === 'removed') &&
+              event.payload.affectedPaths?.length
+            ) {
+              invalidateThumbnailsForPaths(event.payload.affectedPaths);
+            }
+
+            scheduleReconciliation();
+          }
+        );
+
+        if (cancelled) {
+          stopListening();
+          return;
+        }
+        unlisten = stopListening;
+
+        await invoke('start_watching_directory', { path: currentPath });
+        watcherStarted = true;
+
+        if (cancelled) {
+          await invoke('stop_watching_directory', { path: currentPath }).catch(() => undefined);
+          watcherStarted = false;
+        }
+      } catch (error) {
+        if (!cancelled) console.warn('Failed to set up directory watcher:', error);
+      }
+    };
+
+    void setup();
+
+    return () => {
+      cancelled = true;
+      if (reconcileTimer !== undefined) window.clearTimeout(reconcileTimer);
+      unlisten?.();
+      if (watcherStarted) {
+        void invoke('stop_watching_directory', { path: currentPath }).catch(() => undefined);
+      }
+    };
+  }, [currentPath]);
+}

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -65,6 +65,39 @@ const GIT_STATUS_TTL_MS = 5_000;
 let lastOpenWithDefaultPath: string | undefined;
 const activeArchiveExtractions = new Set<string>();
 
+const mergeFileItem = (previous: FileItem, next: FileItem): FileItem => ({
+  ...next,
+  child_count: next.child_count ?? previous.child_count,
+  image_width: next.image_width ?? previous.image_width,
+  image_height: next.image_height ?? previous.image_height,
+  extension: next.extension ?? previous.extension,
+  remote_id: next.remote_id ?? previous.remote_id,
+  thumbnail_url: next.thumbnail_url ?? previous.thumbnail_url,
+  download_url: next.download_url ?? previous.download_url,
+});
+
+/**
+ * Enforce the core file-list invariant: one row per path. Later entries carry the
+ * newest filesystem metadata while locally-computed fields survive the merge.
+ */
+const uniqueFilesByPath = (files: FileItem[], previousFiles: FileItem[] = []): FileItem[] => {
+  const previousByPath = new Map<string, FileItem>();
+  for (const file of previousFiles) {
+    const previous = previousByPath.get(file.path);
+    previousByPath.set(file.path, previous ? mergeFileItem(previous, file) : file);
+  }
+
+  const order: string[] = [];
+  const filesByPath = new Map<string, FileItem>();
+  for (const file of files) {
+    const existing = filesByPath.get(file.path) ?? previousByPath.get(file.path);
+    if (!filesByPath.has(file.path)) order.push(file.path);
+    filesByPath.set(file.path, existing ? mergeFileItem(existing, file) : file);
+  }
+
+  return order.map((path) => filesByPath.get(path)!);
+};
+
 interface GitStatusCacheEntry {
   status: GitStatus | null;
   timestamp: number;
@@ -472,49 +505,21 @@ export const useAppStore = create<AppState>((set, get) => ({
     void get().refreshGitStatus({ path: norm });
   },
   setHomeDir: (path) => set({ homeDir: path }),
-  setFiles: (files) =>
-    set((state) => {
-      const prevByPath = new Map(state.files.map((file) => [file.path, file]));
-      const merged = files.map((file) => {
-        const prev = prevByPath.get(file.path);
-        if (!prev) return file;
-        return {
-          ...file,
-          child_count: file.child_count ?? prev.child_count,
-          image_width: file.image_width ?? prev.image_width,
-          image_height: file.image_height ?? prev.image_height,
-          extension: file.extension ?? prev.extension,
-          remote_id: file.remote_id ?? prev.remote_id,
-          thumbnail_url: file.thumbnail_url ?? prev.thumbnail_url,
-          download_url: file.download_url ?? prev.download_url,
-        };
-      });
-
-      return { files: merged };
-    }),
+  setFiles: (files) => set((state) => ({ files: uniqueFilesByPath(files, state.files) })),
   addFiles: (files) =>
     set((state) => ({
-      files: [...state.files, ...files],
+      files: uniqueFilesByPath([...state.files, ...files]),
     })),
   updateFiles: (updatedFiles) =>
     set((state) => {
       const updateMap = new Map(updatedFiles.map((f) => [f.path, f]));
       return {
-        files: state.files.map((f) => {
-          const updated = updateMap.get(f.path);
-          if (updated) {
-            // Merge updated file data, preserving any locally-computed fields
-            return {
-              ...f,
-              ...updated,
-              // Preserve fields that might have been computed locally
-              child_count: updated.child_count ?? f.child_count,
-              image_width: updated.image_width ?? f.image_width,
-              image_height: updated.image_height ?? f.image_height,
-            };
-          }
-          return f;
-        }),
+        files: uniqueFilesByPath(
+          state.files.map((file) => {
+            const updated = updateMap.get(file.path);
+            return updated ? mergeFileItem(file, updated) : file;
+          })
+        ),
       };
     }),
   removeFilesByPath: (paths) =>
@@ -872,21 +877,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         ? listing.location.raw
         : normalizePath(listing.location.displayPath || listing.location.path);
 
-      const prevByPath = new Map(get().files.map((file) => [file.path, file]));
-      const mergedEntries = listing.entries.map((file) => {
-        const prev = prevByPath.get(file.path);
-        if (!prev) return file;
-        return {
-          ...file,
-          child_count: file.child_count ?? prev.child_count,
-          image_width: file.image_width ?? prev.image_width,
-          image_height: file.image_height ?? prev.image_height,
-          extension: file.extension ?? prev.extension,
-          remote_id: file.remote_id ?? prev.remote_id,
-          thumbnail_url: file.thumbnail_url ?? prev.thumbnail_url,
-          download_url: file.download_url ?? prev.download_url,
-        };
-      });
+      const mergedEntries = uniqueFilesByPath(listing.entries, get().files);
 
       set((state) => {
         const updatedHistory = [...state.pathHistory];
@@ -1026,8 +1017,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         return {};
       }
 
-      // Append new files
-      const newFiles = [...state.files, ...batch.entries];
+      // Streaming retries or overlapping batches must remain idempotent by path.
+      const newFiles = uniqueFilesByPath([...state.files, ...batch.entries]);
 
       return {
         files: newFiles,
@@ -1068,7 +1059,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         };
       });
 
-      return { files: updatedFiles };
+      return { files: uniqueFilesByPath(updatedFiles) };
     });
   },
 


### PR DESCRIPTION
## What changed

- replace incremental watcher event mutations with a debounced, serialized directory reconciliation hook
- treat directory listings as authoritative and enforce one file item per path across refreshes, additions, updates, and streaming batches
- reference-count native watcher registrations so overlapping React setup and cleanup cannot tear down the active watcher
- add regression coverage for notification bursts, duplicate listings, repeated additions, and overlapping streaming batches
- migrate the stale SMB clipboard-image path to the sidecar implementation so the legacy `smb` feature still compiles

## Why

Browser downloads generate bursts of create, modify, rename, and remove notifications. Multiple frontend listeners and append-only store updates could race, inserting the same filesystem path more than once. Because selection is path-based, selecting one duplicate also selected every duplicate row.

The new flow uses filesystem events only as invalidation signals, performs one authoritative directory read after each burst, and reconciles by path.

## Impact

Downloads and other rapidly-changing files should appear exactly once while their containing directory remains open. Watcher lifecycle changes are also safe across navigation and React Strict Mode overlap.

## Validation

- `npm run test:run` — 109 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run check` via pre-push hook
- `cargo check --features smb`
- `cargo build --features smb --bin marlin`
